### PR TITLE
BUGFIX: continue on net.OpError

### DIFF
--- a/worker_test.go
+++ b/worker_test.go
@@ -234,6 +234,23 @@ func TestWorkerDead(t *testing.T) {
 	assert.True(t, (nowEpochSeconds()-job.FailedAt) <= 2)
 }
 
+// Test that in the case of an unavailable Redis server,
+// the worker loop exits in the case of a WorkerPool.Stop
+func TestStop(t *testing.T) {
+	redisPool := &redis.Pool{
+		Dial: func() (redis.Conn, error) {
+			c, err := redis.Dial("tcp", "notworking:6379")
+			if err != nil {
+				return nil, err
+			}
+			return c, nil
+		},
+	}
+	wp := NewWorkerPool(TestContext{}, 10, "work", redisPool)
+	wp.Start()
+	wp.Stop()
+}
+
 func BenchmarkJobProcessing(b *testing.B) {
 	pool := newTestPool(":6379")
 	ns := "work"


### PR DESCRIPTION
I ran into a case where when Redis becomes unavailable, or starts off unavailable, worker.loop will get stuck in case <-timer.C:  when a WorkerPool.Stop is issued.

Note that there is also an issue when Redis isn't available,  the worker loop and the observer loop consume large amounts of CPU trying to reconnect that this doesn't address if WorkerPool.Stop is **not** issued.


