### PR TITLE
Update command to run workwebui in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ go install github.com/gocraft/work/cmd/workwebui
 
 Then, you can run it:
 ```bash
-workwebui -redis=":6379" -ns="work" -listen=":5040"
+workwebui -redis="redis:6379" -ns="work" -listen=":5040"
 ```
 
 Navigate to ```http://localhost:5040/```.


### PR DESCRIPTION
Not sure if this is a bug but if I specify the workwebui redis argument as `":6379"` instead of `"redis:6379"`, i get `missing protocol scheme` errors

```
➜  bin ./workwebui -redis=":6379" -ns="my_app_namespace" -listen=":5040"
Starting workwebui:
redis =  :6379
database =  0
namespace =  my_app_namespace
listen =  :5040
ERROR: client.get_zset_page.values - parse :6379: missing protocol scheme
ERROR: client.scheduled_jobs.get_zset_page - parse :6379: missing protocol scheme
```