### PR TITLE
Fixes issue #24 by not emptying the job queue in a loop, but by resetting the timer

### DIFF
--- a/worker_pool_test.go
+++ b/worker_pool_test.go
@@ -6,6 +6,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"reflect"
 	"testing"
+	"github.com/jalkanen/work"
+	"time"
+	"sync/atomic"
 )
 
 type tstCtx struct {
@@ -109,4 +112,47 @@ func TestWorkerPoolValidations(t *testing.T) {
 
 		wp.Job("wat", TestWorkerPoolValidations)
 	}()
+}
+
+type emptyCtx struct{}
+
+// Starts up a pool with two workers emptying it as fast as they can
+// The pool is Stop()ped while jobs are still going on.  Tests that the
+// pool processing is really stopped and that it's not first completely
+// drained before returning.
+// https://github.com/gocraft/work/issues/24
+func TestWorkerPoolStop(t *testing.T) {
+	ns := "will_it_end"
+	pool := newTestPool(":6379")
+	var started, stopped int32
+	num_iters := 30
+
+	wp := NewWorkerPool(emptyCtx{}, 2, ns, pool)
+
+	wp.Job("sample_job", func (c *emptyCtx, job *Job) error {
+		atomic.AddInt32(&started,1)
+		time.Sleep(1 * time.Second)
+		atomic.AddInt32(&stopped,1)
+		return nil
+	})
+
+	var enqueuer = work.NewEnqueuer(ns, pool)
+
+	for i := 0; i <= num_iters; i++ {
+		enqueuer.Enqueue("sample_job", work.Q{})
+	}
+
+	// Start the pool and quit before it has had a chance to complete
+	// all the jobs.
+	wp.Start()
+	time.Sleep(5 * time.Second)
+	wp.Stop()
+
+	if started != stopped {
+		t.Errorf("Expected that jobs were finished and not killed while processing (started=%d, stopped=%d)",started,stopped)
+	}
+
+	if started >= int32(num_iters) {
+		t.Errorf("Expected that jobs queue was not completely emptied.")
+	}
 }


### PR DESCRIPTION
Includes also an unit test (which unfortunately takes about 5 seconds to run, but I'm not sure if that can be avoided).  Unit tests pass locally.