### PR TITLE
FEATURE: ability to pause workers from processing new jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,8 +291,8 @@ You'll see a view that looks like this:
 
 ## Paused jobs
 
-* You can pause all workers in a worker pool from processing any further jobs by setting a specific "paused" redis key (see `redisKeyJobsPaused`)
-** Conversely, jobs will resume once the paused redis key is removed
+* You can pause jobs from being processed from a specific queue by setting a "paused" redis key (see `redisKeyJobsPaused`)
+* Conversely, jobs in the queue will resume being processed once the paused redis key is removed
 
 ### Terminology reference
 * "worker pool" - a pool of workers
@@ -309,7 +309,7 @@ You'll see a view that looks like this:
 * "retry jobs" - if a job fails and needs to be retried, it will be put on this queue.
 * "scheduled jobs" - jobs enqueued to be run in th future will be put on a scheduled job queue.
 * "dead jobs" - if a job exceeds its MaxFails count, it will be put on the dead job queue.
-* "paused workers" - if workers are paused, then no jobs will be processed by any workers in that worker pool until they are unpaused.
+* "paused jobs" - if paused key is present for a queue, then no jobs from that queue will be processed by any workers until that queue's paused key is removed
 
 ## Benchmarks
 

--- a/README.md
+++ b/README.md
@@ -283,11 +283,16 @@ You'll see a view that looks like this:
 * When a unique job is enqueued, we'll atomically set a redis key that includes the job name and arguments and enqueue the job.
 * When the job is processed, we'll delete that key to permit another job to be enqueued.
 
-### Periodic Jobs
+### Periodic jobs
 
 * You can tell a worker pool to enqueue jobs periodically using a cron schedule.
 * Each worker pool will wake up every 2 minutes, and if jobs haven't been scheduled yet, it will schedule all the jobs that would be executed in the next five minutes.
 * Each periodic job that runs at a given time has a predictable byte pattern. Since jobs are scheduled on the scheduled job queue (a Redis z-set), if the same job is scheduled twice for a given time, it can only exist in the z-set once.
+
+## Paused jobs
+
+* You can pause all workers in a worker pool from processing any further jobs by setting a specific "paused" redis key (see `redisKeyJobsPaused`)
+** Conversely, jobs will resume once the paused redis key is removed
 
 ### Terminology reference
 * "worker pool" - a pool of workers
@@ -301,10 +306,10 @@ You'll see a view that looks like this:
 * "job name" - each job has a name, like "create_watch"
 * "job type" - backend/private nomenclature for the handler+options for processing a job
 * "queue" - each job creates a queue with the same name as the job. only jobs named X go into the X queue.
-* "retry jobs" - If a job fails and needs to be retried, it will be put on this queue.
-* "scheduled jobs" - Jobs enqueued to be run in th future will be put on a scheduled job queue.
-* "dead jobs" - If a job exceeds its MaxFails count, it will be put on the dead job queue.
-
+* "retry jobs" - if a job fails and needs to be retried, it will be put on this queue.
+* "scheduled jobs" - jobs enqueued to be run in th future will be put on a scheduled job queue.
+* "dead jobs" - if a job exceeds its MaxFails count, it will be put on the dead job queue.
+* "paused workers" - if workers are paused, then no jobs will be processed by any workers in that worker pool until they are unpaused.
 
 ## Benchmarks
 

--- a/dead_pool_reaper.go
+++ b/dead_pool_reaper.go
@@ -100,11 +100,11 @@ func (r *deadPoolReaper) reap() error {
 }
 
 func (r *deadPoolReaper) requeueInProgressJobs(poolID string, jobTypes []string) error {
-	redisRequeueScript := redis.NewScript(len(jobTypes)*2, redisLuaRpoplpushMultiCmd)
+	redisRequeueScript := redis.NewScript(len(jobTypes)*3, redisLuaRpoplpushMultiCmd)
 
-	var scriptArgs = make([]interface{}, 0, len(jobTypes)*2)
+	var scriptArgs = make([]interface{}, 0, len(jobTypes)*3)
 	for _, jobType := range jobTypes {
-		scriptArgs = append(scriptArgs, redisKeyJobsInProgress(r.namespace, poolID, jobType), redisKeyJobs(r.namespace, jobType))
+		scriptArgs = append(scriptArgs, redisKeyJobsInProgress(r.namespace, poolID, jobType), redisKeyJobs(r.namespace, jobType), redisKeyJobsPaused(r.namespace, jobType))
 	}
 
 	conn := r.pool.Get()

--- a/priority_sampler.go
+++ b/priority_sampler.go
@@ -15,13 +15,15 @@ type sampleItem struct {
 	// payload:
 	redisJobs       string
 	redisJobsInProg string
+	redisJobsPaused string
 }
 
-func (s *prioritySampler) add(priority uint, redisJobs, redisJobsInProg string) {
+func (s *prioritySampler) add(priority uint, redisJobs, redisJobsInProg, redisJobsPaused string) {
 	sample := sampleItem{
 		priority:        priority,
 		redisJobs:       redisJobs,
 		redisJobsInProg: redisJobsInProg,
+		redisJobsPaused: redisJobsPaused,
 	}
 	s.samples = append(s.samples, sample)
 	s.sum += priority

--- a/priority_sampler_test.go
+++ b/priority_sampler_test.go
@@ -8,9 +8,9 @@ import (
 
 func TestPrioritySampler(t *testing.T) {
 	ps := prioritySampler{}
-	ps.add(5, "jobs.5", "jobsinprog.5")
-	ps.add(2, "jobs.2a", "jobsinprog.2a")
-	ps.add(1, "jobs.1b", "jobsinprog.1b")
+	ps.add(5, "jobs.5", "jobsinprog.5", "jobs.5.paused")
+	ps.add(2, "jobs.2a", "jobsinprog.2a", "jobs.2a.paused")
+	ps.add(1, "jobs.1b", "jobsinprog.1b", "jobs.1b.paused")
 
 	var c5 = 0
 	var c2 = 0
@@ -41,7 +41,7 @@ func TestPrioritySampler(t *testing.T) {
 func BenchmarkPrioritySampler(b *testing.B) {
 	ps := prioritySampler{}
 	for i := 0; i < 200; i++ {
-		ps.add(uint(i)+1, "jobs."+fmt.Sprint(i), "jobsinprog."+fmt.Sprint(i))
+		ps.add(uint(i)+1, "jobs."+fmt.Sprint(i), "jobsinprog."+fmt.Sprint(i), "jobspaused."+fmt.Sprint(i))
 	}
 
 	b.ResetTimer()

--- a/worker_test.go
+++ b/worker_test.go
@@ -310,7 +310,7 @@ func TestWorkersPaused(t *testing.T) {
 	w := newWorker(ns, "1", pool, tstCtxType, nil, jobTypes)
 	// pause the jobs prior to starting
 	pauseJobs(ns, job1, pool)
-	// reset the backoff times to help with testing here
+	// reset the backoff times to help with testing
 	sleepBackoffsInMilliseconds = []int64{10, 10, 10, 10, 10}
 	w.start()
 
@@ -325,7 +325,6 @@ func TestWorkersPaused(t *testing.T) {
 	unpauseJobs(ns, job1, pool)
 	// sleep through 2 backoffs to make sure we allow enough time to start running
 	time.Sleep(20 * time.Millisecond)
-	// Make sure to sleep enough to let the timer expire (see sleepBackoffsInMilliseconds)
 	assert.EqualValues(t, 0, listSize(pool, redisKeyJobs(ns, job1)))
 	assert.EqualValues(t, 1, listSize(pool, redisKeyJobsInProgress(ns, "1", job1)))
 

--- a/worker_test.go
+++ b/worker_test.go
@@ -328,7 +328,6 @@ func TestWorkersPaused(t *testing.T) {
 	assert.EqualValues(t, 0, listSize(pool, redisKeyJobs(ns, job1)))
 	assert.EqualValues(t, 1, listSize(pool, redisKeyJobsInProgress(ns, "1", job1)))
 
-	// nothing in the worker status
 	w.observer.drain()
 	h := readHash(pool, redisKeyWorkerObservation(ns, w.workerID))
 	assert.Equal(t, job1, h["job_name"])


### PR DESCRIPTION
The purpose of the PR is to provide functionality for pausing workers from pulling more jobs off of the run queue (within a given redis instance). The new key to pause a run queue looks like (for example_:

  `${namespace}:jobs:${jobName}:paused`

Using the previous example, the semantics are if this key is present then no new jobs will be processed for the `${namespace}:jobs:${jobName}` run queue. 