### PR TITLE
FEATURE: ability to run jobs exclusively for a job queue

### DIFF
--- a/dead_pool_reaper.go
+++ b/dead_pool_reaper.go
@@ -106,7 +106,7 @@ func (r *deadPoolReaper) requeueInProgressJobs(poolID string, jobTypes []string)
 
 	scriptArgs = append(scriptArgs, redisKeyExclusiveJobs(r.namespace))
 	for _, jobType := range jobTypes {
-		scriptArgs = append(scriptArgs, redisKeyJobsInProgress(r.namespace, poolID, jobType), redisKeyJobs(r.namespace, jobType), redisKeyJobsPaused(r.namespace, jobType))
+		scriptArgs = append(scriptArgs, redisKeyJobsInProgress(r.namespace, poolID, jobType), redisKeyJobs(r.namespace, jobType), redisKeyJobsPaused(r.namespace, jobType), redisKeyJobsLocked(r.namespace, jobType))
 	}
 
 	conn := r.pool.Get()

--- a/dead_pool_reaper.go
+++ b/dead_pool_reaper.go
@@ -100,9 +100,11 @@ func (r *deadPoolReaper) reap() error {
 }
 
 func (r *deadPoolReaper) requeueInProgressJobs(poolID string, jobTypes []string) error {
-	redisRequeueScript := redis.NewScript(len(jobTypes)*3, redisLuaRpoplpushMultiCmd)
+	numArgs := numArgsFetchJobLuaScript(len(jobTypes))
+	redisRequeueScript := redis.NewScript(numArgs, redisLuaRpoplpushMultiCmd)
+	var scriptArgs = make([]interface{}, 0, numArgs)
 
-	var scriptArgs = make([]interface{}, 0, len(jobTypes)*3)
+	scriptArgs = append(scriptArgs, redisKeyExclusiveJobs(r.namespace))
 	for _, jobType := range jobTypes {
 		scriptArgs = append(scriptArgs, redisKeyJobsInProgress(r.namespace, poolID, jobType), redisKeyJobs(r.namespace, jobType), redisKeyJobsPaused(r.namespace, jobType))
 	}

--- a/priority_sampler.go
+++ b/priority_sampler.go
@@ -5,8 +5,8 @@ import (
 )
 
 type prioritySampler struct {
-	sum     uint
-	samples []sampleItem
+	sum           uint
+	samples       []sampleItem
 }
 
 type sampleItem struct {

--- a/priority_sampler.go
+++ b/priority_sampler.go
@@ -5,8 +5,8 @@ import (
 )
 
 type prioritySampler struct {
-	sum           uint
-	samples       []sampleItem
+	sum     uint
+	samples []sampleItem
 }
 
 type sampleItem struct {

--- a/priority_sampler.go
+++ b/priority_sampler.go
@@ -16,14 +16,16 @@ type sampleItem struct {
 	redisJobs       string
 	redisJobsInProg string
 	redisJobsPaused string
+	redisJobsLocked string
 }
 
-func (s *prioritySampler) add(priority uint, redisJobs, redisJobsInProg, redisJobsPaused string) {
+func (s *prioritySampler) add(priority uint, redisJobs, redisJobsInProg, redisJobsPaused string, redisJobsLocked string) {
 	sample := sampleItem{
 		priority:        priority,
 		redisJobs:       redisJobs,
 		redisJobsInProg: redisJobsInProg,
 		redisJobsPaused: redisJobsPaused,
+		redisJobsLocked: redisJobsLocked,
 	}
 	s.samples = append(s.samples, sample)
 	s.sum += priority

--- a/priority_sampler_test.go
+++ b/priority_sampler_test.go
@@ -8,9 +8,9 @@ import (
 
 func TestPrioritySampler(t *testing.T) {
 	ps := prioritySampler{}
-	ps.add(5, "jobs.5", "jobsinprog.5", "jobs.5.paused")
-	ps.add(2, "jobs.2a", "jobsinprog.2a", "jobs.2a.paused")
-	ps.add(1, "jobs.1b", "jobsinprog.1b", "jobs.1b.paused")
+	ps.add(5, "jobs.5", "jobsinprog.5", "jobs.5.paused", "jobs.5.locked")
+	ps.add(2, "jobs.2a", "jobsinprog.2a", "jobs.2a.paused", "jobs.5.locked")
+	ps.add(1, "jobs.1b", "jobsinprog.1b", "jobs.1b.paused", "jobs.5.locked")
 
 	var c5 = 0
 	var c2 = 0
@@ -41,7 +41,7 @@ func TestPrioritySampler(t *testing.T) {
 func BenchmarkPrioritySampler(b *testing.B) {
 	ps := prioritySampler{}
 	for i := 0; i < 200; i++ {
-		ps.add(uint(i)+1, "jobs."+fmt.Sprint(i), "jobsinprog."+fmt.Sprint(i), "jobspaused."+fmt.Sprint(i))
+		ps.add(uint(i)+1, "jobs."+fmt.Sprint(i), "jobsinprog."+fmt.Sprint(i), "jobspaused."+fmt.Sprint(i), "jobslocked."+fmt.Sprint(i))
 	}
 
 	b.ResetTimer()

--- a/redis.go
+++ b/redis.go
@@ -64,6 +64,10 @@ func redisKeyJobsPaused(namespace, jobName string) string {
 	return fmt.Sprintf("%s:%s", redisKeyJobs(namespace, jobName), "paused")
 }
 
+func redisKeyJobsLocked(namespace, jobName string) string {
+	return fmt.Sprintf("%s:%s", redisKeyJobs(namespace, jobName), "locked")
+}
+
 func redisKeyUniqueJob(namespace, jobName string, args map[string]interface{}) (string, error) {
 	var buf bytes.Buffer
 
@@ -87,45 +91,59 @@ func redisKeyLastPeriodicEnqueue(namespace string) string {
 }
 
 // To help with usages of redisLuaRpoplpushMultiCmd
-// 3 args per job + 1 arg for exclusive set (which is per namespace)
+// 4 args per job + 1 arg for exclusive set (which is per namespace)
 func numArgsFetchJobLuaScript(numJobTypes int) int {
-	return (numJobTypes * 3) + 1
+	return (numJobTypes * 4) + 1
 }
 
-// KEYS[1] = the 1st job queue we want to try, eg, "work:jobs:emails"
-// KEYS[2] = the 1st job queue's in prog queue, eg, "work:jobs:emails:97c84119d13cb54119a38743:inprogress"
-// KEYS[3] = the 1st job queue's paused key, eg, "work:jobs:emails:paused"
-// KEYS[4] = the 2nd job queue...
-// KEYS[5] = the 2nd job queue's in prog queue...
-// KEYS[6] = the 2nd job queue's paused key...
+// KEYS[1] = the set of jobs that are to run jobs exclusively
+// KEYS[2] = the 1st job queue we want to try, eg, "work:jobs:emails"
+// KEYS[3] = the 1st job queue's in prog queue, eg, "work:jobs:emails:97c84119d13cb54119a38743:inprogress"
+// KEYS[4] = the 1st job queue's paused key, eg, "work:jobs:emails:paused"
+// KEYS[5] = the 1st job queue's lock key, e.g., "work:jobs:emails:locked"
+// KEYS[6] = the 2nd job queue...
+// KEYS[7] = the 2nd job queue's in prog queue...
+// KEYS[8] = the 2nd job queue's paused key...
+// KEYS[9] = the 2nd job queue's locked key...
 // ...
 // KEYS[N] = the last job queue...
 // KEYS[N+1] = the last job queue's in prog queue...
 // KEYS[N+2] = the last job queue's paused key...
+// KEYS[N+3] = the last job queue's locked key...
 var redisLuaRpoplpushMultiCmd = `
-local function isPaused(pausekey)
-  return redis.call('get', pausekey)
+local function isPaused(p)
+  return redis.call('get', p)
 end
 
-local function isExclusive(queueName, exclQueues)
-  return redis.call('sismember', exclQueues, queueName) == 1
+local function isLocked(l)
+  return redis.call('get', l)
 end
 
-local function checkRunExclusive(queueName, pauseKey, exclQueues)
-  if isExclusive(queueName, exclQueues) then
-    redis.call('set', pauseKey, '1')
+local function isExclusive(q, exc)
+  return redis.call('sismember', exc, q) == 1
+end
+
+local function runExclusive(q, l, exc)
+  if isExclusive(q, exc) then
+    redis.call('set', l, '1')
   end
 end
 
-local res
+local res, runQueue, inProgQueue, pauseKey, lockedKey
 local exclQueues = KEYS[1]
 local keylen = #KEYS - 1
-for i=2,keylen,3 do
-  if not isPaused(KEYS[i+2]) then
-    res = redis.call('rpoplpush', KEYS[i], KEYS[i+1])
+
+for i=2,keylen,4 do
+  runQueue = KEYS[i]
+  inProgQueue = KEYS[i+1]
+  pauseKey = KEYS[i+2]
+  lockedKey = KEYS[i+3]
+
+  if not isPaused(pauseKey) and not isLocked(lockedKey) then
+    res = redis.call('rpoplpush', runQueue, inProgQueue)
     if res then
-      checkRunExclusive(KEYS[i], KEYS[i+2], exclQueues)
-      return {res, KEYS[i], KEYS[i+1]}
+      runExclusive(runQueue, lockedKey, exclQueues)
+      return {res, runQueue, inProgQueue}
     end
   end
 end

--- a/redis.go
+++ b/redis.go
@@ -299,3 +299,20 @@ if redis.call('set', KEYS[2], '1', 'NX', 'EX', '86400') then
 end
 return 'dup'
 `
+
+// KEYS[1] = jobs run queue
+// KEYS[2] = job types lock key
+var redisLuaCheckStaleQueueLocks = `
+local function isLocked(lockedKey)
+  return redis.call('get', lockedKey)
+end
+
+local function isInProgress(runQueue)
+  return redis.call('keys', runQueue .. ':*:inprogress')
+end
+
+if isLocked(KEYS[2]) and next(isInProgress(KEYS[1])) == nil then
+  return 1
+end
+return 0
+`

--- a/worker.go
+++ b/worker.go
@@ -187,14 +187,14 @@ func (w *worker) processJob(job *Job) {
 		job.observer = w.observer // for Checkin
 		_, runErr := runJob(job, w.contextType, w.middleware, jt)
 		w.observeDone(job.Name, job.ID, runErr)
-		if jt.RunExclusiveJobs {
-			w.unlockRunQueue(job.Name)
-		}
 		if runErr != nil {
 			job.failed(runErr)
 			w.addToRetryOrDead(jt, job, runErr)
 		} else {
 			w.removeJobFromInProgress(job)
+		}
+		if jt.RunExclusiveJobs {
+			w.unlockRunQueue(job.Name)
 		}
 	} else {
 		// NOTE: since we don't have a jobType, we don't know max retries

--- a/worker_test.go
+++ b/worker_test.go
@@ -291,7 +291,7 @@ func TestWorkersPaused(t *testing.T) {
 	job1 := "job1"
 	deleteQueue(pool, ns, job1)
 	deleteRetryAndDead(pool, ns)
-	deletePausedAndLockedKey(ns, job1, pool)
+	deletePausedAndLockedKeys(ns, job1, pool)
 
 	jobTypes := make(map[string]*jobType)
 	jobTypes[job1] = &jobType{
@@ -535,7 +535,7 @@ func unpauseJobs(namespace, jobName string, pool *redis.Pool) error {
 	return nil
 }
 
-func deletePausedAndLockedKey(namespace, jobName string, pool *redis.Pool) error {
+func deletePausedAndLockedKeys(namespace, jobName string, pool *redis.Pool) error {
 	conn := pool.Get()
 	defer conn.Close()
 
@@ -547,3 +547,14 @@ func deletePausedAndLockedKey(namespace, jobName string, pool *redis.Pool) error
 	}
 	return nil
 }
+
+func createQueueLock(pool *redis.Pool, namespace, jobName string) error {
+	conn := pool.Get()
+	defer conn.Close()
+
+	if _, err := conn.Do("SET", redisKeyJobsLocked(namespace, jobName), "1"); err != nil {
+		return err
+	}
+	return nil
+}
+

--- a/worker_test.go
+++ b/worker_test.go
@@ -291,6 +291,7 @@ func TestWorkersPaused(t *testing.T) {
 	job1 := "job1"
 	deleteQueue(pool, ns, job1)
 	deleteRetryAndDead(pool, ns)
+	deletePausedAndLockedKey(ns, job1, pool)
 
 	jobTypes := make(map[string]*jobType)
 	jobTypes[job1] = &jobType{
@@ -534,11 +535,14 @@ func unpauseJobs(namespace, jobName string, pool *redis.Pool) error {
 	return nil
 }
 
-func deletePausedKey(namespace, jobName string, pool *redis.Pool) error {
+func deletePausedAndLockedKey(namespace, jobName string, pool *redis.Pool) error {
 	conn := pool.Get()
 	defer conn.Close()
 
 	if _, err := conn.Do("DEL", redisKeyJobsPaused(namespace, jobName)); err != nil {
+		return err
+	}
+	if _, err := conn.Do("DEL", redisKeyJobsLocked(namespace, jobName)); err != nil {
 		return err
 	}
 	return nil

--- a/worker_test.go
+++ b/worker_test.go
@@ -533,3 +533,13 @@ func unpauseJobs(namespace, jobName string, pool *redis.Pool) error {
 	}
 	return nil
 }
+
+func deletePausedKey(namespace, jobName string, pool *redis.Pool) error {
+	conn := pool.Get()
+	defer conn.Close()
+
+	if _, err := conn.Do("DEL", redisKeyJobsPaused(namespace, jobName)); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
The purpose of this PR is allow for the definition of jobs that should run work exclusively -- that is, at most one job executing -- by setting the `JobOptions {RunExclusiveJobs: true}`. For example:

  `worker_pool.JobWithOptions(jobName, JobOptions{RunExclusiveJobs: true}, (*Context).WorkFxn)`

This is accomplished by introducing a queue lock that is:

- checked before a new job is fetched
- set once a new job is fetched, if the jobs are marked to run exclusivley
- cleared once job has finished (in the event of success or error)

We also check for any stale queue locks during worker pool startup and clean those up.

**QA tests run:**

1. Test Case 1: _verify only one job is active at a time_ 
    - create a worker pool with concurrency >= num of jobs and set `RunExclusiveJobs = true` via JobOptions
    - start the worker pool
    - enqueue a bunch of jobs
    - during the duration of the job execution, check the `inprogress` queue and make sure there is never > 1 job in progress at any time
2. Test Case 2:  _new worker pool is starting up and detects an active queue lock, leaves lock in place_
    - manually create the queue lock and manually create an inprogress key
    - start a new worker pool in the same namespace/job name
    - verify that the stale lock is still in place
3. Test Case 3: _new worker pool is starting up and detects a stale queue lock_
    - manually create the queue lock and manually delete any inprogress keys
    - start a new worker pool in the same namespace/job name
    - verify that the stale lock was removed
4. Test Case 4: _verify that exclusive jobs can be paused_
    - start exclusive jobs
    - try to pause exclusive job execution 
    - observe that they stop running
    - unpause and observe that they resume execution
