### PR TITLE
FEATURE: add MaxConcurrency control to job options

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,10 @@ You'll see a view that looks like this:
 * This works by putting a precondition on enqueuing function, meaning a new job will not be scheduled if we are at or over a job's `MaxConcurrency` limit
 * A redis key (see `redisKeyJobsLock`) is used as a counting semaphore in order to track job concurrency per job type
 * The default value is `0`, which means "no limit on job concurrency"
+* **Note:** if you want to run jobs "single threaded" then you can set the `MaxConcurrency` accordingly:
+```go
+      worker_pool.JobWithOptions(jobName, JobOptions{MaxConcurrency: 1}, (*Context).WorkFxn)
+```
 
 ### Terminology reference
 * "worker pool" - a pool of workers

--- a/dead_pool_reaper.go
+++ b/dead_pool_reaper.go
@@ -104,9 +104,9 @@ func (r *deadPoolReaper) requeueInProgressJobs(poolID string, jobTypes []string)
 	redisRequeueScript := redis.NewScript(numArgs, redisLuaRpoplpushMultiCmd)
 	var scriptArgs = make([]interface{}, 0, numArgs)
 
-	scriptArgs = append(scriptArgs, redisKeyExclusiveJobs(r.namespace))
 	for _, jobType := range jobTypes {
-		scriptArgs = append(scriptArgs, redisKeyJobsInProgress(r.namespace, poolID, jobType), redisKeyJobs(r.namespace, jobType), redisKeyJobsPaused(r.namespace, jobType), redisKeyJobsLocked(r.namespace, jobType))
+		// TODO: I think there is a bug below: order of redisKeyJobsInProgress and redisKeyJobs should be switched according to redisLuaRpoplpushMultiCmd
+		scriptArgs = append(scriptArgs, redisKeyJobsInProgress(r.namespace, poolID, jobType), redisKeyJobs(r.namespace, jobType))
 	}
 
 	conn := r.pool.Get()

--- a/dead_pool_reaper.go
+++ b/dead_pool_reaper.go
@@ -106,7 +106,7 @@ func (r *deadPoolReaper) requeueInProgressJobs(poolID string, jobTypes []string)
 
 	scriptArgs = append(scriptArgs, redisKeyExclusiveJobs(r.namespace))
 	for _, jobType := range jobTypes {
-		scriptArgs = append(scriptArgs, redisKeyJobsInProgress(r.namespace, poolID, jobType), redisKeyJobs(r.namespace, jobType), redisKeyJobsPaused(r.namespace, jobType))
+		scriptArgs = append(scriptArgs, redisKeyJobsInProgress(r.namespace, poolID, jobType), redisKeyJobs(r.namespace, jobType), redisKeyJobsPaused(r.namespace, jobType), redisKeyJobsLocked(r.namespace, jobType))
 	}
 
 	conn := r.pool.Get()

--- a/dead_pool_reaper.go
+++ b/dead_pool_reaper.go
@@ -105,6 +105,7 @@ func (r *deadPoolReaper) requeueInProgressJobs(poolID string, jobTypes []string)
 	var scriptArgs = make([]interface{}, 0, numArgs)
 
 	for _, jobType := range jobTypes {
+		// pop from in progress and push into job queue
 		scriptArgs = append(scriptArgs, redisKeyJobsInProgress(r.namespace, poolID, jobType), redisKeyJobs(r.namespace, jobType))
 	}
 

--- a/dead_pool_reaper.go
+++ b/dead_pool_reaper.go
@@ -100,9 +100,11 @@ func (r *deadPoolReaper) reap() error {
 }
 
 func (r *deadPoolReaper) requeueInProgressJobs(poolID string, jobTypes []string) error {
-	redisRequeueScript := redis.NewScript(len(jobTypes)*3, redisLuaRpoplpushMultiCmd)
+	numArgs := numArgsFetchJobLuaScript(len(jobTypes))
+	redisRequeueScript := redis.NewScript(numArgs, redisLuaRpoplpushMultiCmd)
+	var scriptArgs = make([]interface{}, 0, numArgs)
 
-	var scriptArgs = make([]interface{}, 0, len(jobTypes)*3)
+	scriptArgs = append(scriptArgs, redisKeyExclusiveJobs(r.namespace))
 	for _, jobType := range jobTypes {
 		scriptArgs = append(scriptArgs, redisKeyJobsInProgress(r.namespace, poolID, jobType), redisKeyJobs(r.namespace, jobType), redisKeyJobsPaused(r.namespace, jobType))
 	}

--- a/dead_pool_reaper.go
+++ b/dead_pool_reaper.go
@@ -100,7 +100,7 @@ func (r *deadPoolReaper) reap() error {
 }
 
 func (r *deadPoolReaper) requeueInProgressJobs(poolID string, jobTypes []string) error {
-	numArgs := numArgsFetchJobLuaScript(len(jobTypes))
+	numArgs := len(jobTypes) * 2
 	redisRequeueScript := redis.NewScript(numArgs, redisLuaRpoplpushMultiCmd)
 	var scriptArgs = make([]interface{}, 0, numArgs)
 

--- a/dead_pool_reaper.go
+++ b/dead_pool_reaper.go
@@ -101,11 +101,11 @@ func (r *deadPoolReaper) reap() error {
 
 func (r *deadPoolReaper) requeueInProgressJobs(poolID string, jobTypes []string) error {
 	numArgs := len(jobTypes) * 2
-	redisRequeueScript := redis.NewScript(numArgs, redisLuaRpoplpushMultiCmd)
+	redisRequeueScript := redis.NewScript(numArgs, redisLuaReenqueueJob)
 	var scriptArgs = make([]interface{}, 0, numArgs)
 
 	for _, jobType := range jobTypes {
-		// pop from in progress and push into job queue
+		// pops from in progress, push into job queue and decrement the queue lock
 		scriptArgs = append(scriptArgs, redisKeyJobsInProgress(r.namespace, poolID, jobType), redisKeyJobs(r.namespace, jobType))
 	}
 

--- a/dead_pool_reaper.go
+++ b/dead_pool_reaper.go
@@ -105,7 +105,6 @@ func (r *deadPoolReaper) requeueInProgressJobs(poolID string, jobTypes []string)
 	var scriptArgs = make([]interface{}, 0, numArgs)
 
 	for _, jobType := range jobTypes {
-		// TODO: I think there is a bug below: order of redisKeyJobsInProgress and redisKeyJobs should be switched according to redisLuaRpoplpushMultiCmd
 		scriptArgs = append(scriptArgs, redisKeyJobsInProgress(r.namespace, poolID, jobType), redisKeyJobs(r.namespace, jobType))
 	}
 

--- a/dead_pool_reaper_test.go
+++ b/dead_pool_reaper_test.go
@@ -55,6 +55,8 @@ func TestDeadPoolReaper(t *testing.T) {
 	// Test requeueing jobs
 	_, err = conn.Do("lpush", redisKeyJobsInProgress(ns, "2", "type1"), "foo")
 	assert.NoError(t, err)
+	_, err = conn.Do("incr", redisKeyJobsLocked(ns, "type1"))
+	assert.NoError(t, err)
 
 	// Ensure 0 jobs in jobs queue
 	jobsCount, err := redis.Int(conn.Do("llen", redisKeyJobs(ns, "type1")))
@@ -79,6 +81,11 @@ func TestDeadPoolReaper(t *testing.T) {
 	jobsCount, err = redis.Int(conn.Do("llen", redisKeyJobsInProgress(ns, "2", "type1")))
 	assert.NoError(t, err)
 	assert.Equal(t, 0, jobsCount)
+
+	// Lock count should get decremented
+	lockCount, err := redis.Int(conn.Do("get", redisKeyJobsLocked(ns, "type1")))
+	assert.NoError(t, err)
+	assert.Equal(t, 0, lockCount)
 }
 
 func TestDeadPoolReaperNoHeartbeat(t *testing.T) {

--- a/dead_pool_reaper_test.go
+++ b/dead_pool_reaper_test.go
@@ -55,7 +55,7 @@ func TestDeadPoolReaper(t *testing.T) {
 	// Test requeueing jobs
 	_, err = conn.Do("lpush", redisKeyJobsInProgress(ns, "2", "type1"), "foo")
 	assert.NoError(t, err)
-	_, err = conn.Do("incr", redisKeyJobsLocked(ns, "type1"))
+	_, err = conn.Do("incr", redisKeyJobsLock(ns, "type1"))
 	assert.NoError(t, err)
 
 	// Ensure 0 jobs in jobs queue
@@ -83,7 +83,7 @@ func TestDeadPoolReaper(t *testing.T) {
 	assert.Equal(t, 0, jobsCount)
 
 	// Lock count should get decremented
-	lockCount, err := redis.Int(conn.Do("get", redisKeyJobsLocked(ns, "type1")))
+	lockCount, err := redis.Int(conn.Do("get", redisKeyJobsLock(ns, "type1")))
 	assert.NoError(t, err)
 	assert.Equal(t, 0, lockCount)
 }

--- a/enqueue.go
+++ b/enqueue.go
@@ -98,7 +98,10 @@ func (e *Enqueuer) EnqueueIn(jobName string, secondsFromNow int64, args map[stri
 	return scheduledJob, nil
 }
 
-// EnqueueUnique enqueues a job unless a job is already enqueued with the same name and arguments. The already-enqueued job can be in the normal work queue or in the scheduled job queue. Once a worker begins processing a job, another job with the same name and arguments can be enqueued again. Any failed jobs in the retry queue or dead queue don't count against the uniqueness -- so if a job fails and is retried, two unique jobs with the same name and arguments can be enqueued at once.
+// EnqueueUnique enqueues a job unless a job is already enqueued with the same name and arguments.
+// The already-enqueued job can be in the normal work queue or in the scheduled job queue.
+// Once a worker begins processing a job, another job with the same name and arguments can be enqueued again.
+// Any failed jobs in the retry queue or dead queue don't count against the uniqueness -- so if a job fails and is retried, two unique jobs with the same name and arguments can be enqueued at once.
 // In order to add robustness to the system, jobs are only unique for 24 hours after they're enqueued. This is mostly relevant for scheduled jobs.
 // EnqueueUnique returns the job if it was enqueued and nil if it wasn't
 func (e *Enqueuer) EnqueueUnique(jobName string, args map[string]interface{}) (*Job, error) {

--- a/enqueue_test.go
+++ b/enqueue_test.go
@@ -134,7 +134,7 @@ func TestEnqueueUnique(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, job)
 
-	// Process the queues. Ensure the right numbero of jobs was processed
+	// Process the queues. Ensure the right number of jobs were processed
 	var wats, taws int64
 	wp := NewWorkerPool(TestContext{}, 3, ns, pool)
 	wp.JobWithOptions("wat", JobOptions{Priority: 1, MaxFails: 1}, func(job *Job) error {

--- a/enqueue_test.go
+++ b/enqueue_test.go
@@ -2,9 +2,11 @@ package work
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
+	"sync"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestEnqueue(t *testing.T) {
@@ -101,7 +103,7 @@ func TestEnqueueUnique(t *testing.T) {
 	ns := "work"
 	cleanKeyspace(ns, pool)
 	enqueuer := NewEnqueuer(ns, pool)
-
+	var mutex = &sync.Mutex{}
 	job, err := enqueuer.EnqueueUnique("wat", Q{"a": 1, "b": "cool"})
 	assert.NoError(t, err)
 	if assert.NotNil(t, job) {
@@ -138,11 +140,15 @@ func TestEnqueueUnique(t *testing.T) {
 	var wats, taws int64
 	wp := NewWorkerPool(TestContext{}, 3, ns, pool)
 	wp.JobWithOptions("wat", JobOptions{Priority: 1, MaxFails: 1}, func(job *Job) error {
+		mutex.Lock()
 		wats++
+		mutex.Unlock()
 		return nil
 	})
 	wp.JobWithOptions("taw", JobOptions{Priority: 1, MaxFails: 1}, func(job *Job) error {
+		mutex.Lock()
 		taws++
+		mutex.Unlock()
 		return fmt.Errorf("ohno")
 	})
 	wp.Start()

--- a/priority_sampler.go
+++ b/priority_sampler.go
@@ -5,8 +5,8 @@ import (
 )
 
 type prioritySampler struct {
-	sum     uint
-	samples []sampleItem
+	sum           uint
+	samples       []sampleItem
 }
 
 type sampleItem struct {

--- a/priority_sampler.go
+++ b/priority_sampler.go
@@ -5,8 +5,8 @@ import (
 )
 
 type prioritySampler struct {
-	sum           uint
-	samples       []sampleItem
+	sum     uint
+	samples []sampleItem
 }
 
 type sampleItem struct {

--- a/priority_sampler.go
+++ b/priority_sampler.go
@@ -15,17 +15,13 @@ type sampleItem struct {
 	// payload:
 	redisJobs       string
 	redisJobsInProg string
-	redisJobsPaused string
-	redisJobsLocked string
 }
 
-func (s *prioritySampler) add(priority uint, redisJobs, redisJobsInProg, redisJobsPaused string, redisJobsLocked string) {
+func (s *prioritySampler) add(priority uint, redisJobs, redisJobsInProg string) {
 	sample := sampleItem{
 		priority:        priority,
 		redisJobs:       redisJobs,
 		redisJobsInProg: redisJobsInProg,
-		redisJobsPaused: redisJobsPaused,
-		redisJobsLocked: redisJobsLocked,
 	}
 	s.samples = append(s.samples, sample)
 	s.sum += priority

--- a/priority_sampler.go
+++ b/priority_sampler.go
@@ -16,14 +16,16 @@ type sampleItem struct {
 	redisJobs       string
 	redisJobsInProg string
 	redisJobsPaused string
+	redisJobsLocked string
 }
 
-func (s *prioritySampler) add(priority uint, redisJobs, redisJobsInProg, redisJobsPaused string) {
+func (s *prioritySampler) add(priority uint, redisJobs, redisJobsInProg, redisJobsPaused string, redisJobsLocked string) {
 	sample := sampleItem{
 		priority:        priority,
 		redisJobs:       redisJobs,
 		redisJobsInProg: redisJobsInProg,
 		redisJobsPaused: redisJobsPaused,
+		redisJobsLocked: redisJobsLocked,
 	}
 	s.samples = append(s.samples, sample)
 	s.sum += priority

--- a/priority_sampler_test.go
+++ b/priority_sampler_test.go
@@ -8,9 +8,9 @@ import (
 
 func TestPrioritySampler(t *testing.T) {
 	ps := prioritySampler{}
-	ps.add(5, "jobs.5", "jobsinprog.5", "jobs.5.paused", "jobs.5.locked")
-	ps.add(2, "jobs.2a", "jobsinprog.2a", "jobs.2a.paused", "jobs.5.locked")
-	ps.add(1, "jobs.1b", "jobsinprog.1b", "jobs.1b.paused", "jobs.5.locked")
+	ps.add(5, "jobs.5", "jobsinprog.5")
+	ps.add(2, "jobs.2a", "jobsinprog.2a")
+	ps.add(1, "jobs.1b", "jobsinprog.1b")
 
 	var c5 = 0
 	var c2 = 0
@@ -41,7 +41,7 @@ func TestPrioritySampler(t *testing.T) {
 func BenchmarkPrioritySampler(b *testing.B) {
 	ps := prioritySampler{}
 	for i := 0; i < 200; i++ {
-		ps.add(uint(i)+1, "jobs."+fmt.Sprint(i), "jobsinprog."+fmt.Sprint(i), "jobspaused."+fmt.Sprint(i), "jobslocked."+fmt.Sprint(i))
+		ps.add(uint(i)+1, "jobs."+fmt.Sprint(i), "jobsinprog."+fmt.Sprint(i))
 	}
 
 	b.ResetTimer()

--- a/priority_sampler_test.go
+++ b/priority_sampler_test.go
@@ -8,9 +8,9 @@ import (
 
 func TestPrioritySampler(t *testing.T) {
 	ps := prioritySampler{}
-	ps.add(5, "jobs.5", "jobsinprog.5", "jobs.5.paused")
-	ps.add(2, "jobs.2a", "jobsinprog.2a", "jobs.2a.paused")
-	ps.add(1, "jobs.1b", "jobsinprog.1b", "jobs.1b.paused")
+	ps.add(5, "jobs.5", "jobsinprog.5", "jobs.5.paused", "jobs.5.locked")
+	ps.add(2, "jobs.2a", "jobsinprog.2a", "jobs.2a.paused", "jobs.5.locked")
+	ps.add(1, "jobs.1b", "jobsinprog.1b", "jobs.1b.paused", "jobs.5.locked")
 
 	var c5 = 0
 	var c2 = 0
@@ -41,7 +41,7 @@ func TestPrioritySampler(t *testing.T) {
 func BenchmarkPrioritySampler(b *testing.B) {
 	ps := prioritySampler{}
 	for i := 0; i < 200; i++ {
-		ps.add(uint(i)+1, "jobs."+fmt.Sprint(i), "jobsinprog."+fmt.Sprint(i), "jobspaused."+fmt.Sprint(i))
+		ps.add(uint(i)+1, "jobs."+fmt.Sprint(i), "jobsinprog."+fmt.Sprint(i), "jobspaused."+fmt.Sprint(i), "jobslocked."+fmt.Sprint(i))
 	}
 
 	b.ResetTimer()

--- a/redis.go
+++ b/redis.go
@@ -139,7 +139,8 @@ local function isPaused(pauseKey)
 end
 
 local function canRun(lockKey, maxConcurrency)
-  local activeJobs = redis.call('get', lockKey)
+  local activeJobs = tonumber(redis.call('get', lockKey))
+
   if not maxConcurrency or maxConcurrency == 0 then
     -- default case: maxConcurrency not defined or set to 0 means no cap on concurrent jobs
     return true
@@ -165,7 +166,7 @@ for i=1,keylen,2 do
   inProgQueue = KEYS[i+1]
   pauseKey = getPauseKey(jobQueue)
   lockKey = getLockKey(jobQueue)
-  maxConcurrency = redis.call('get', getConcurrencyKey(jobQueue))
+  maxConcurrency = tonumber(redis.call('get', getConcurrencyKey(jobQueue)))
 
   if haveJobs(jobQueue) and not isPaused(pauseKey) and canRun(lockKey, maxConcurrency) then
     res = redis.call('rpoplpush', jobQueue, inProgQueue)

--- a/redis.go
+++ b/redis.go
@@ -18,10 +18,6 @@ func redisKeyKnownJobs(namespace string) string {
 	return redisNamespacePrefix(namespace) + "known_jobs"
 }
 
-func redisKeyExclusiveJobs(namespace string) string {
-	return redisNamespacePrefix(namespace) + "exclusive_jobs"
-}
-
 // returns "<namespace>:jobs:"
 // so that we can just append the job name and be good to go
 func redisKeyJobsPrefix(namespace string) string {
@@ -30,6 +26,10 @@ func redisKeyJobsPrefix(namespace string) string {
 
 func redisKeyJobs(namespace, jobName string) string {
 	return redisKeyJobsPrefix(namespace) + jobName
+}
+
+func redisKeyJobsConfig(namespace, jobName string) string {
+	return redisKeyJobs(namespace, jobName) + ":config"
 }
 
 func redisKeyJobsInProgress(namespace, poolID, jobName string) string {
@@ -93,58 +93,58 @@ func redisKeyLastPeriodicEnqueue(namespace string) string {
 // To help with usages of redisLuaRpoplpushMultiCmd
 // 4 args per job + 1 arg for exclusive set (which is per namespace)
 func numArgsFetchJobLuaScript(numJobTypes int) int {
-	return (numJobTypes * 4) + 1
+	return (numJobTypes * 2)
 }
 
-// KEYS[1] = the set of jobs that are to run jobs exclusively
-// KEYS[2] = the 1st job queue we want to try, eg, "work:jobs:emails"
-// KEYS[3] = the 1st job queue's in prog queue, eg, "work:jobs:emails:97c84119d13cb54119a38743:inprogress"
-// KEYS[4] = the 1st job queue's paused key, eg, "work:jobs:emails:paused"
-// KEYS[5] = the 1st job queue's lock key, e.g., "work:jobs:emails:locked"
-// KEYS[6] = the 2nd job queue...
-// KEYS[7] = the 2nd job queue's in prog queue...
-// KEYS[8] = the 2nd job queue's paused key...
-// KEYS[9] = the 2nd job queue's locked key...
+// KEYS[1] = the 1st job queue we want to try, eg, "work:jobs:emails"
+// KEYS[2] = the 1st job queue's in prog queue, eg, "work:jobs:emails:97c84119d13cb54119a38743:inprogress"
+// KEYS[3] = the 2nd job queue...
+// KEYS[4] = the 2nd job queue's in prog queue...
 // ...
 // KEYS[N] = the last job queue...
 // KEYS[N+1] = the last job queue's in prog queue...
-// KEYS[N+2] = the last job queue's paused key...
-// KEYS[N+3] = the last job queue's locked key...
 var redisLuaRpoplpushMultiCmd = `
-local function isPaused(p)
-  return redis.call('get', p)
+local function haveJobs(jobQueue)
+  return redis.call('llen', jobQueue) > 0
 end
 
-local function isLocked(l)
-  return redis.call('get', l)
+local function isPaused(pauseKey)
+  return redis.call('get', pauseKey)
 end
 
-local function isExclusive(q, exc)
-  return redis.call('sismember', exc, q) == 1
-end
-
-local function runExclusive(q, l, exc)
-  if isExclusive(q, exc) then
-    redis.call('set', l, '1')
+local function canRun(lockKey, maxConcurrency)
+  local activeJobs = redis.call('get', lockKey)
+  if not maxConcurrency or maxConcurrency == 0 then
+    -- default case: maxConcurrency not defined or set to 0 means no cap on concurrent jobs
+    return true
+  elseif not activeJobs then
+    -- maxConcurrency set, but lock does not yet exist
+    redis.call('set', lockKey, 1)
+    return true
+  elseif activeJobs < maxConcurrency then
+    -- maxConcurrency set, lock is set, but not yet at max concurrency
+    redis.call('incr', lockKey)
+    return true
+  else
+    -- we are at max capacity for running jobs
+    return false
   end
 end
 
-local res, runQueue, inProgQueue, pauseKey, lockedKey
-local exclQueues = KEYS[1]
-local keylen = #KEYS - 1
+local res, jobQueue, configKey, inProgQueue, pauseKey, lockKey, maxConcurrency
+local keylen = #KEYS
 
-for i=2,keylen,4 do
-  runQueue = KEYS[i]
+for i=1,keylen,2 do
+  jobQueue = KEYS[i]
   inProgQueue = KEYS[i+1]
-  pauseKey = KEYS[i+2]
-  lockedKey = KEYS[i+3]
+  configKey = jobQueue .. ':config'
+  pauseKey = redis.call('hget', configKey, 'pause_key')
+  lockKey = redis.call('hget', configKey, 'lock_key')
+  maxConcurrency = redis.call('hget', configKey, 'max_concurrency')
 
-  if not isPaused(pauseKey) and not isLocked(lockedKey) then
-    res = redis.call('rpoplpush', runQueue, inProgQueue)
-    if res then
-      runExclusive(runQueue, lockedKey, exclQueues)
-      return {res, runQueue, inProgQueue}
-    end
+  if haveJobs(jobQueue) and not isPaused(pauseKey) and canRun(lockKey, maxConcurrency) then
+    res = redis.call('rpoplpush', jobQueue, inProgQueue)
+    return {res, jobQueue, inProgQueue}
   end
 end
 return nil
@@ -307,8 +307,8 @@ local function isLocked(lockedKey)
   return redis.call('get', lockedKey)
 end
 
-local function isInProgress(runQueue)
-  return redis.call('keys', runQueue .. ':*:inprogress')
+local function isInProgress(jobQueue)
+  return redis.call('keys', jobQueue .. ':*:inprogress')
 end
 
 if isLocked(KEYS[2]) and next(isInProgress(KEYS[1])) == nil then

--- a/redis.go
+++ b/redis.go
@@ -90,12 +90,6 @@ func redisKeyLastPeriodicEnqueue(namespace string) string {
 	return redisNamespacePrefix(namespace) + "last_periodic_enqueue"
 }
 
-// To help with usages of redisLuaFetchJob
-// 4 args per job + 1 arg for exclusive set (which is per namespace)
-func numArgsFetchJobLuaScript(numJobTypes int) int {
-	return (numJobTypes * 2)
-}
-
 // Used by Lua scripts below and needs to follow same naming convention as redisKeyJobs* functions above
 var redisLuaJobsPausedKey = `
 local function getPauseKey(jobQueue)

--- a/redis.go
+++ b/redis.go
@@ -157,16 +157,15 @@ local function canRun(lockKey, maxConcurrency)
   end
 end
 
-local res, jobQueue, configKey, inProgQueue, pauseKey, lockKey, maxConcurrency
+local res, jobQueue, inProgQueue, pauseKey, lockKey, maxConcurrency
 local keylen = #KEYS
 
 for i=1,keylen,2 do
   jobQueue = KEYS[i]
   inProgQueue = KEYS[i+1]
-  configKey = jobQueue .. ':config'
   pauseKey = getPauseKey(jobQueue)
   lockKey = getLockKey(jobQueue)
-  maxConcurrency = getConcurrencyKey(jobQueue)
+  maxConcurrency = redis.call('get', getConcurrencyKey(jobQueue))
 
   if haveJobs(jobQueue) and not isPaused(pauseKey) and canRun(lockKey, maxConcurrency) then
     res = redis.call('rpoplpush', jobQueue, inProgQueue)

--- a/redis.go
+++ b/redis.go
@@ -64,6 +64,10 @@ func redisKeyJobsPaused(namespace, jobName string) string {
 	return fmt.Sprintf("%s:%s", redisKeyJobs(namespace, jobName), "paused")
 }
 
+func redisKeyJobsLocked(namespace, jobName string) string {
+	return fmt.Sprintf("%s:%s", redisKeyJobs(namespace, jobName), "locked")
+}
+
 func redisKeyUniqueJob(namespace, jobName string, args map[string]interface{}) (string, error) {
 	var buf bytes.Buffer
 
@@ -87,45 +91,59 @@ func redisKeyLastPeriodicEnqueue(namespace string) string {
 }
 
 // To help with usages of redisLuaRpoplpushMultiCmd
-// 3 args per job + 1 arg for exclusive set (which is per namespace)
+// 4 args per job + 1 arg for exclusive set (which is per namespace)
 func numArgsFetchJobLuaScript(numJobTypes int) int {
-	return (numJobTypes * 3) + 1
+	return (numJobTypes * 4) + 1
 }
 
-// KEYS[1] = the 1st job queue we want to try, eg, "work:jobs:emails"
-// KEYS[2] = the 1st job queue's in prog queue, eg, "work:jobs:emails:97c84119d13cb54119a38743:inprogress"
-// KEYS[3] = the 1st job queue's paused key, eg, "work:jobs:emails:paused"
-// KEYS[4] = the 2nd job queue...
-// KEYS[5] = the 2nd job queue's in prog queue...
-// KEYS[6] = the 2nd job queue's paused key...
+// KEYS[1] = the set of jobs that are to run jobs exclusively
+// KEYS[2] = the 1st job queue we want to try, eg, "work:jobs:emails"
+// KEYS[3] = the 1st job queue's in prog queue, eg, "work:jobs:emails:97c84119d13cb54119a38743:inprogress"
+// KEYS[4] = the 1st job queue's paused key, eg, "work:jobs:emails:paused"
+// KEYS[5] = the 1st job queue's lock key, e.g., "work:jobs:emails:locked"
+// KEYS[6] = the 2nd job queue...
+// KEYS[7] = the 2nd job queue's in prog queue...
+// KEYS[8] = the 2nd job queue's paused key...
+// KEYS[9] = the 2nd job queue's locked key...
 // ...
 // KEYS[N] = the last job queue...
 // KEYS[N+1] = the last job queue's in prog queue...
 // KEYS[N+2] = the last job queue's paused key...
+// KEYS[N+3] = the last job queue's locked key...
 var redisLuaRpoplpushMultiCmd = `
-local function isPaused(pausekey)
-  return redis.call('get', pausekey)
+local function isPaused(p)
+  return redis.call('get', p)
 end
 
-local function isExclusive(queueName, exclQueues)
-  return redis.call('sismember', exclQueues, queueName) == 1
+local function isLocked(l)
+  return redis.call('get', l)
 end
 
-local function checkRunExclusive(queueName, pauseKey, exclQueues)
-  if isExclusive(queueName, exclQueues) then
-    redis.call('set', pauseKey, '1')
+local function isExclusive(q, exc)
+  return redis.call('sismember', exc, q) == 1
+end
+
+local function runExclusive(q, l, exc)
+  if isExclusive(q, exc) then
+    redis.call('set', l, '1')
   end
 end
 
-local res
+local res, runQueue, inProgQueue, pauseKey, lockedKey
 local exclQueues = KEYS[1]
 local keylen = #KEYS - 1
-for i=2,keylen,3 do
-  if not isPaused(KEYS[i+2]) then
-    res = redis.call('rpoplpush', KEYS[i], KEYS[i+1])
+
+for i=2,keylen,4 do
+  runQueue = KEYS[i]
+  inProgQueue = KEYS[i+1]
+  pauseKey = KEYS[i+2]
+  lockedKey = KEYS[i+3]
+
+  if not isPaused(pauseKey) and not isLocked(lockedKey) then
+    res = redis.call('rpoplpush', runQueue, inProgQueue)
     if res then
-      checkRunExclusive(KEYS[i], KEYS[i+2], exclQueues)
-      return {res, KEYS[i], KEYS[i+1]}
+      runExclusive(runQueue, lockedKey, exclQueues)
+      return {res, runQueue, inProgQueue}
     end
   end
 end

--- a/redis.go
+++ b/redis.go
@@ -299,3 +299,20 @@ if redis.call('set', KEYS[2], '1', 'NX', 'EX', '86400') then
 end
 return 'dup'
 `
+
+// KEYS[1] = jobs run queue
+// KEYS[2] = job types lock key
+var redisLuaCheckStaleQueueLocks = `
+local function isLocked(lockedKey)
+  return redis.call('get', lockedKey)
+end
+
+local function isInProgress(runQueue)
+  return redis.call('keys', runQueue .. ':*:inprogress')
+end
+
+if isLocked(KEYS[2]) and next(isInProgress(KEYS[1])) == nil then
+  return 1
+end
+return 0
+`

--- a/redis.go
+++ b/redis.go
@@ -28,10 +28,6 @@ func redisKeyJobs(namespace, jobName string) string {
 	return redisKeyJobsPrefix(namespace) + jobName
 }
 
-func redisKeyJobsConfig(namespace, jobName string) string {
-	return redisKeyJobs(namespace, jobName) + ":config"
-}
-
 func redisKeyJobsInProgress(namespace, poolID, jobName string) string {
 	return fmt.Sprintf("%s:%s:inprogress", redisKeyJobs(namespace, jobName), poolID)
 }
@@ -61,11 +57,15 @@ func redisKeyHeartbeat(namespace, workerPoolID string) string {
 }
 
 func redisKeyJobsPaused(namespace, jobName string) string {
-	return fmt.Sprintf("%s:%s", redisKeyJobs(namespace, jobName), "paused")
+	return redisKeyJobs(namespace, jobName) + ":paused"
 }
 
 func redisKeyJobsLocked(namespace, jobName string) string {
-	return fmt.Sprintf("%s:%s", redisKeyJobs(namespace, jobName), "locked")
+	return redisKeyJobs(namespace, jobName) + ":locked"
+}
+
+func redisKeyJobsConcurrency(namespace, jobName string) string {
+	return redisKeyJobs(namespace, jobName) + ":max_concurrency"
 }
 
 func redisKeyUniqueJob(namespace, jobName string, args map[string]interface{}) (string, error) {
@@ -96,6 +96,25 @@ func numArgsFetchJobLuaScript(numJobTypes int) int {
 	return (numJobTypes * 2)
 }
 
+// Used by Lua scripts below and needs to follow same naming convention as redisKeyJobs* functions above
+var redisLuaJobsPausedKey = `
+local function getPauseKey(jobQueue)
+  return string.format("%s:paused", jobQueue)
+end
+`
+
+var redisLuaJobsLockedKey = `
+local function getLockKey(jobQueue)
+  return string.format("%s:locked", jobQueue)
+end
+`
+
+var redisLuaJobsConcurrencyKey = `
+local function getConcurrencyKey(jobQueue)
+  return string.format("%s:max_concurrency", jobQueue)
+end
+`
+
 // KEYS[1] = the 1st job queue we want to try, eg, "work:jobs:emails"
 // KEYS[2] = the 1st job queue's in prog queue, eg, "work:jobs:emails:97c84119d13cb54119a38743:inprogress"
 // KEYS[3] = the 2nd job queue...
@@ -103,7 +122,14 @@ func numArgsFetchJobLuaScript(numJobTypes int) int {
 // ...
 // KEYS[N] = the last job queue...
 // KEYS[N+1] = the last job queue's in prog queue...
-var redisLuaRpoplpushMultiCmd = `
+var redisLuaRpoplpushMultiCmd = fmt.Sprintf(`
+-- getPauseKey will be inserted below
+%s
+-- getLockKey will be inserted below
+%s
+-- getConcurrencyKey will be inserted below
+%s
+
 local function haveJobs(jobQueue)
   return redis.call('llen', jobQueue) > 0
 end
@@ -138,9 +164,9 @@ for i=1,keylen,2 do
   jobQueue = KEYS[i]
   inProgQueue = KEYS[i+1]
   configKey = jobQueue .. ':config'
-  pauseKey = redis.call('hget', configKey, 'pause_key')
-  lockKey = redis.call('hget', configKey, 'lock_key')
-  maxConcurrency = redis.call('hget', configKey, 'max_concurrency')
+  pauseKey = getPauseKey(jobQueue)
+  lockKey = getLockKey(jobQueue)
+  maxConcurrency = getConcurrencyKey(jobQueue)
 
   if haveJobs(jobQueue) and not isPaused(pauseKey) and canRun(lockKey, maxConcurrency) then
     res = redis.call('rpoplpush', jobQueue, inProgQueue)
@@ -148,7 +174,7 @@ for i=1,keylen,2 do
   end
 end
 return nil
-`
+`, redisLuaJobsPausedKey, redisLuaJobsLockedKey, redisLuaJobsConcurrencyKey)
 
 // KEYS[1] = zset of jobs (retry or scheduled), eg work:retry
 // KEYS[2] = zset of dead, eg work:dead. If we don't know the jobName of a job, we'll put it in dead.
@@ -301,8 +327,10 @@ return 'dup'
 `
 
 // KEYS[1] = jobs run queue
-// KEYS[2] = job types lock key
-var redisLuaCheckStaleQueueLocks = `
+var redisLuaCheckStaleQueueLocks = fmt.Sprintf(`
+-- getLockKey will be inserted below
+%s
+
 local function isLocked(lockedKey)
   return redis.call('get', lockedKey)
 end
@@ -311,8 +339,9 @@ local function isInProgress(jobQueue)
   return redis.call('keys', jobQueue .. ':*:inprogress')
 end
 
-if isLocked(KEYS[2]) and next(isInProgress(KEYS[1])) == nil then
+local jobQueue = KEYS[1]
+if isLocked(getLockKey(jobQueue)) and next(isInProgress(jobQueue)) == nil then
   return 1
 end
 return 0
-`
+`, redisLuaJobsLockedKey)

--- a/worker.go
+++ b/worker.go
@@ -143,7 +143,7 @@ func (w *worker) fetchJob() (*Job, error) {
 
 	conn := w.pool.Get()
 	defer conn.Close()
-	// fmt.Printf("scriptArgs=%v\n", scriptArgs)
+
 	values, err := redis.Values(w.redisFetchScript.Do(conn, scriptArgs...))
 	if err == redis.ErrNil {
 		return nil, nil

--- a/worker.go
+++ b/worker.go
@@ -187,14 +187,14 @@ func (w *worker) processJob(job *Job) {
 		job.observer = w.observer // for Checkin
 		_, runErr := runJob(job, w.contextType, w.middleware, jt)
 		w.observeDone(job.Name, job.ID, runErr)
-		if jt.RunExclusiveJobs {
-			w.unlockRunQueue(job.Name)
-		}
 		if runErr != nil {
 			job.failed(runErr)
 			w.addToRetryOrDead(jt, job, runErr)
 		} else {
 			w.removeJobFromInProgress(job)
+		}
+		if jt.RunExclusiveJobs {
+			w.unlockRunQueue(job.Name)
 		}
 	} else {
 		// NOTE: since we don't have a jobType, we don't know max retries

--- a/worker.go
+++ b/worker.go
@@ -63,7 +63,7 @@ func (w *worker) updateMiddlewareAndJobTypes(middleware []*middlewareHandler, jo
 	}
 	w.sampler = sampler
 	w.jobTypes = jobTypes
-	w.redisFetchScript = redis.NewScript(numArgsFetchJobLuaScript(len(jobTypes)), redisLuaFetchJob)
+	w.redisFetchScript = redis.NewScript(len(jobTypes)*2, redisLuaFetchJob)
 }
 
 func (w *worker) start() {
@@ -135,7 +135,7 @@ func (w *worker) fetchJob() (*Job, error) {
 	// resort queues
 	// NOTE: we could optimize this to only resort every second, or something.
 	w.sampler.sample()
-	var scriptArgs = make([]interface{}, 0, numArgsFetchJobLuaScript(len(w.sampler.samples)))
+	var scriptArgs = make([]interface{}, 0, len(w.sampler.samples)*2)
 
 	for _, s := range w.sampler.samples {
 		scriptArgs = append(scriptArgs, s.redisJobs, s.redisJobsInProg)

--- a/worker.go
+++ b/worker.go
@@ -63,7 +63,7 @@ func (w *worker) updateMiddlewareAndJobTypes(middleware []*middlewareHandler, jo
 	}
 	w.sampler = sampler
 	w.jobTypes = jobTypes
-	w.redisFetchScript = redis.NewScript(numArgsFetchJobLuaScript(len(jobTypes)), redisLuaRpoplpushMultiCmd)
+	w.redisFetchScript = redis.NewScript(numArgsFetchJobLuaScript(len(jobTypes)), redisLuaFetchJob)
 }
 
 func (w *worker) start() {

--- a/worker_pool.go
+++ b/worker_pool.go
@@ -277,11 +277,9 @@ func (wp *WorkerPool) writeConcurrencyControlsToRedis() {
 		if _, err := conn.Do("SET", redisKeyJobsConcurrency(wp.namespace, jobName), jobType.MaxConcurrency); err != nil {
 			logError("write_concurrency_controls_max_concurrency", err)
 		}
-		// this shouldn't be necessary since Lua fetch fxn will handled this case too, but it doesn't hurt
-		if jobType.MaxConcurrency > 0 {
-			if _, err := conn.Do("SET", redisKeyJobsLocked(wp.namespace, jobName), 0); err != nil {
-				logError("write_concurrency_controls_init_lock_key", err)
-			}
+		// Need to set up the lock in case concurrency is throttled at runtime
+		if _, err := conn.Do("SET", redisKeyJobsLocked(wp.namespace, jobName), 0); err != nil {
+			logError("write_concurrency_controls_init_lock_key", err)
 		}
 	}
 }

--- a/worker_pool.go
+++ b/worker_pool.go
@@ -176,7 +176,7 @@ func (wp *WorkerPool) Start() {
 
 	wp.removeStaleQueueLocks()
 	wp.writeConfigHash()
-	wp.writeKnownJobsToRedis()
+	go wp.writeKnownJobsToRedis()
 
 	for _, w := range wp.workers {
 		go w.start()

--- a/worker_pool_test.go
+++ b/worker_pool_test.go
@@ -201,7 +201,7 @@ func TestWorkerPoolStartCleansStaleQueueLocks(t *testing.T) {
 	assert.NoError(t, err)
 
 	// make sure stale lock is deleted
-	wp.removeStaleQueueLocks()
+	wp.removeStaleKeys()
 	lockedKey, err := conn.Do("GET", redisKeyJobsLocked(ns, job1))
 	assert.NoError(t, err)
 	assert.Nil(t, lockedKey)
@@ -223,7 +223,7 @@ func TestWorkerPoolStartSkipsInProgressQueueLocks(t *testing.T) {
 	assert.NoError(t, err)
 
 	// make sure active queue locks are not deleted
-	wp.removeStaleQueueLocks()
+	wp.removeStaleKeys()
 	lockedKey, err := conn.Do("GET", redisKeyJobsLocked(ns, job1))
 	assert.NoError(t, err)
 	assert.NotNil(t, lockedKey)

--- a/worker_test.go
+++ b/worker_test.go
@@ -547,14 +547,3 @@ func deletePausedAndLockedKeys(namespace, jobName string, pool *redis.Pool) erro
 	}
 	return nil
 }
-
-func createQueueLock(pool *redis.Pool, namespace, jobName string) error {
-	conn := pool.Get()
-	defer conn.Close()
-
-	if _, err := conn.Do("SET", redisKeyJobsLocked(namespace, jobName), "1"); err != nil {
-		return err
-	}
-	return nil
-}
-

--- a/worker_test.go
+++ b/worker_test.go
@@ -542,7 +542,7 @@ func deletePausedAndLockedKeys(namespace, jobName string, pool *redis.Pool) erro
 	if _, err := conn.Do("DEL", redisKeyJobsPaused(namespace, jobName)); err != nil {
 		return err
 	}
-	if _, err := conn.Do("DEL", redisKeyJobsLocked(namespace, jobName)); err != nil {
+	if _, err := conn.Do("DEL", redisKeyJobsLock(namespace, jobName)); err != nil {
 		return err
 	}
 	return nil

--- a/worker_test.go
+++ b/worker_test.go
@@ -291,7 +291,7 @@ func TestWorkersPaused(t *testing.T) {
 	job1 := "job1"
 	deleteQueue(pool, ns, job1)
 	deleteRetryAndDead(pool, ns)
-	deletePausedAndLockedKey(ns, job1, pool)
+	deletePausedAndLockedKeys(ns, job1, pool)
 
 	jobTypes := make(map[string]*jobType)
 	jobTypes[job1] = &jobType{
@@ -535,7 +535,7 @@ func unpauseJobs(namespace, jobName string, pool *redis.Pool) error {
 	return nil
 }
 
-func deletePausedAndLockedKey(namespace, jobName string, pool *redis.Pool) error {
+func deletePausedAndLockedKeys(namespace, jobName string, pool *redis.Pool) error {
 	conn := pool.Get()
 	defer conn.Close()
 
@@ -547,3 +547,14 @@ func deletePausedAndLockedKey(namespace, jobName string, pool *redis.Pool) error
 	}
 	return nil
 }
+
+func createQueueLock(pool *redis.Pool, namespace, jobName string) error {
+	conn := pool.Get()
+	defer conn.Close()
+
+	if _, err := conn.Do("SET", redisKeyJobsLocked(namespace, jobName), "1"); err != nil {
+		return err
+	}
+	return nil
+}
+

--- a/worker_test.go
+++ b/worker_test.go
@@ -291,6 +291,7 @@ func TestWorkersPaused(t *testing.T) {
 	job1 := "job1"
 	deleteQueue(pool, ns, job1)
 	deleteRetryAndDead(pool, ns)
+	deletePausedAndLockedKey(ns, job1, pool)
 
 	jobTypes := make(map[string]*jobType)
 	jobTypes[job1] = &jobType{
@@ -534,11 +535,14 @@ func unpauseJobs(namespace, jobName string, pool *redis.Pool) error {
 	return nil
 }
 
-func deletePausedKey(namespace, jobName string, pool *redis.Pool) error {
+func deletePausedAndLockedKey(namespace, jobName string, pool *redis.Pool) error {
 	conn := pool.Get()
 	defer conn.Close()
 
 	if _, err := conn.Do("DEL", redisKeyJobsPaused(namespace, jobName)); err != nil {
+		return err
+	}
+	if _, err := conn.Do("DEL", redisKeyJobsLocked(namespace, jobName)); err != nil {
 		return err
 	}
 	return nil

--- a/worker_test.go
+++ b/worker_test.go
@@ -533,3 +533,13 @@ func unpauseJobs(namespace, jobName string, pool *redis.Pool) error {
 	}
 	return nil
 }
+
+func deletePausedKey(namespace, jobName string, pool *redis.Pool) error {
+	conn := pool.Get()
+	defer conn.Close()
+
+	if _, err := conn.Do("DEL", redisKeyJobsPaused(namespace, jobName)); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
The purpose of this PR is to provide the `MaxConcurrency` job option that will control the max number of active jobs running at once across all workers for a specific job type (within one redis instance). For example:

  `worker_pool.JobWithOptions(jobName, JobOptions{MaxConcurrency: 1}, (*Context).WorkFxn)`

The above would ensure that jobs of that type never run more than 1 active job at a time. The default value is `MaxConcurrency = 0`, which is the current behavior (max concurrency would be the number of workers for that job * number of distinct processes running those workers).

This is accomplished by introducing a redis key that is used as a counting semaphore to lock a job queue. This lock is:

- checked before a new job is fetched
- incremented once a new job is fetched, if the jobs have `MaxConcurrency > 0`
- decremented once the job has finished (in the event of success or error)

We also check for any stale queue locks during worker pool startup and clean those up.

**QA tests run:**

1. Test Case 1: _verify only one job is active at a time_ 
    - create a worker pool with concurrency >= num of jobs and set `MaxConcurrency = 1` via JobOptions
    - start the worker pool
    - enqueue a bunch of jobs
    - during the duration of the job execution, check the `inprogress` queue and make sure there is never > 1 job in progress at any time
2. Test Case 2:  _new worker pool is starting up and detects an active queue lock, leaves lock in place_
    - manually create the queue lock and manually create an inprogress key
    - start a new worker pool in the same namespace/job name
    - verify that the stale lock is still in place
3. Test Case 3: _new worker pool is starting up and detects a stale queue lock_
    - manually create the queue lock and manually delete any inprogress keys
    - start a new worker pool in the same namespace/job name
    - verify that the stale lock was removed
4. Test Case 4: _verify that exclusive jobs can be paused_
    - start exclusive jobs
    - try to pause exclusive job execution 
    - observe that they stop running
    - unpause and observe that they resume execution
5. Functional tests for:
  - pausing / unpausing jobs
  - max concurrency default (no limit) and with limit