### PR TITLE
BUGFIX: comment out stale key check from startup process

### DIFF
--- a/redis.go
+++ b/redis.go
@@ -349,6 +349,7 @@ var redisRemoveStaleKeys = fmt.Sprintf(`
 -- getConcurrencyKey will be inserted below
 %s
 
+-- TODO: need something more efficient than KEYS cmd
 local function isInProgress(jobQueue)
   return redis.call('keys', jobQueue .. ':*:inprogress')
 end

--- a/worker_pool.go
+++ b/worker_pool.go
@@ -174,7 +174,8 @@ func (wp *WorkerPool) Start() {
 	}
 	wp.started = true
 
-	wp.removeStaleKeys()
+	// TODO: need to fix Lua script to remove stale keys
+	// wp.removeStaleKeys()
 	wp.writeConcurrencyControlsToRedis()
 	go wp.writeKnownJobsToRedis()
 


### PR DESCRIPTION
"KEYS" command was killing startup of clustered redis (need to revisit the cleanup script)≥