### PR TITLE
BUGFIX: reap jobs in the event of dirty shutdown

### DIFF
--- a/heartbeater_test.go
+++ b/heartbeater_test.go
@@ -8,6 +8,13 @@ import (
 	"time"
 )
 
+func TestHeartBeatExpiration(t *testing.T) {
+	// just to make sure -- heartbeats should not expire before the reaper has had a chance to assess whether or
+	// not jobs are dead (in the event of a dirty shutdown, for example)
+	assert.True(t, heartbeatExpiration > deadTime)
+	assert.True(t, heartbeatExpiration > reapPeriod + reapJitterSecs * time.Second)
+}
+
 func TestHeartbeater(t *testing.T) {
 	pool := newTestPool(":6379")
 	ns := "work"


### PR DESCRIPTION
Fixes #44 (reworked since last PR).

QA performed:
1. perform a hard/dirty shutdown that will leave stale jobs in progress
2. wait for ~10 minutes for the second reap cycle to detect dead jobs (stale jobs older than 5 min)
3. verify that the job lock is decremented by the amount of stale jobs that were in queue, old worker pool is removed from the worker_pool set, and the old in progress queue is cleaned up