### PR TITLE
Cleanup dead worker pools with no heartbeat

### DIFF
--- a/heartbeater.go
+++ b/heartbeater.go
@@ -81,7 +81,7 @@ func (h *workerPoolHeartbeater) loop() {
 	for {
 		select {
 		case <-h.stopChan:
-			h.removeHeartbeat() // TODO: why do we do this here?
+			h.removeHeartbeat()
 			h.doneStoppingChan <- struct{}{}
 			return
 		case <-ticker:

--- a/heartbeater.go
+++ b/heartbeater.go
@@ -81,7 +81,7 @@ func (h *workerPoolHeartbeater) loop() {
 	for {
 		select {
 		case <-h.stopChan:
-			h.removeHeartbeat()
+			h.removeHeartbeat() // TODO: why do we do this here?
 			h.doneStoppingChan <- struct{}{}
 			return
 		case <-ticker:

--- a/observer.go
+++ b/observer.go
@@ -120,7 +120,7 @@ func (o *observer) observeCheckin(jobName, jobID, checkin string) {
 }
 
 func (o *observer) loop() {
-	// Ever tick, we'll update redis if necessary
+	// Every tick we'll update redis if necessary
 	// We don't update it on every job because the only purpose of this data is for humans to inspect the system,
 	// and a fast worker could move onto new jobs every few ms.
 	ticker := time.Tick(1000 * time.Millisecond)

--- a/worker_pool.go
+++ b/worker_pool.go
@@ -69,7 +69,8 @@ type middlewareHandler struct {
 	GenericMiddlewareHandler GenericMiddlewareHandler
 }
 
-// NewWorkerPool creates a new worker pool. ctx should be a struct literal whose type will be used for middleware and handlers. concurrency specifies how many workers to spin up - each worker can process jobs concurrently.
+// NewWorkerPool creates a new worker pool. ctx should be a struct literal whose type will be used for middleware and handlers.
+// concurrency specifies how many workers to spin up - each worker can process jobs concurrently.
 func NewWorkerPool(ctx interface{}, concurrency uint, namespace string, pool *redis.Pool) *WorkerPool {
 	if pool == nil {
 		panic("NewWorkerPool needs a non-nil *redis.Pool")
@@ -127,7 +128,8 @@ func (wp *WorkerPool) Job(name string, fn interface{}) *WorkerPool {
 	return wp.JobWithOptions(name, JobOptions{}, fn)
 }
 
-// JobWithOptions adds a handler for 'name' jobs as per the Job function, but permits you specify additional options such as a job's priority, retry count, and whether to send dead jobs to the dead job queue or trash them.
+// JobWithOptions adds a handler for 'name' jobs as per the Job function, but permits you specify additional options
+// such as a job's priority, retry count, and whether to send dead jobs to the dead job queue or trash them.
 func (wp *WorkerPool) JobWithOptions(name string, jobOpts JobOptions, fn interface{}) *WorkerPool {
 	jobOpts = applyDefaultsAndValidate(jobOpts)
 
@@ -277,15 +279,6 @@ func (wp *WorkerPool) writeConcurrencyControlsToRedis() {
 		if _, err := conn.Do("SET", redisKeyJobsConcurrency(wp.namespace, jobName), jobType.MaxConcurrency); err != nil {
 			logError("write_concurrency_controls_max_concurrency", err)
 		}
-	}
-}
-
-func newJobTypeGeneric(name string, opts JobOptions, handler GenericHandler) *jobType {
-	return &jobType{
-		Name:           name,
-		JobOptions:     opts,
-		IsGeneric:      true,
-		GenericHandler: handler,
 	}
 }
 


### PR DESCRIPTION
Small cleanup to remove worker pool ids from the set of known worker pools during reaping if no heartbeat key is found.

Some considerations:

- worker_pools set and heartbeat key are created / deleted together, atomically
- assumption is that a worker_pool id should not exist without a heartbeat key and still be considered alive
