### PR TITLE
Reap stale locks

### DIFF
--- a/dead_pool_reaper.go
+++ b/dead_pool_reaper.go
@@ -106,13 +106,13 @@ func (r *deadPoolReaper) reap() error {
 }
 
 func (r *deadPoolReaper) requeueInProgressJobs(poolID string, jobTypes []string) error {
-	numArgs := len(jobTypes) * 2
+	numArgs := len(jobTypes) * 3
 	redisRequeueScript := redis.NewScript(numArgs, redisLuaReenqueueJob)
 	var scriptArgs = make([]interface{}, 0, numArgs)
 
 	for _, jobType := range jobTypes {
 		// pops from in progress, push into job queue and decrement the queue lock
-		scriptArgs = append(scriptArgs, redisKeyJobsInProgress(r.namespace, poolID, jobType), redisKeyJobs(r.namespace, jobType))
+		scriptArgs = append(scriptArgs, redisKeyJobsInProgress(r.namespace, poolID, jobType), redisKeyJobs(r.namespace, jobType), poolID)
 	}
 
 	conn := r.pool.Get()

--- a/dead_pool_reaper.go
+++ b/dead_pool_reaper.go
@@ -93,12 +93,33 @@ func (r *deadPoolReaper) reap() error {
 				return err
 			}
 		}
-
 		// Remove dead pool from worker pools set
-		_, err = conn.Do("SREM", workerPoolsKey, deadPoolID)
-		if err != nil {
+		if _, err = conn.Do("SREM", workerPoolsKey, deadPoolID); err != nil {
 			return err
 		}
+		// Cleanup any stale lock info
+		if err = r.cleanStaleLockInfo(deadPoolID, jobTypes); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *deadPoolReaper) cleanStaleLockInfo(poolID string, jobTypes []string) error {
+	numKeys := len(jobTypes) * 2
+	redisReapLocksScript := redis.NewScript(numKeys, redisLuaReapStaleLocks)
+	var scriptArgs = make([]interface{}, 0, numKeys+1) // +1 for argv[1]
+
+	for _, jobType := range jobTypes {
+		scriptArgs = append(scriptArgs, redisKeyJobsLock(r.namespace, jobType), redisKeyJobsLockInfo(r.namespace, jobType))
+	}
+	scriptArgs = append(scriptArgs, poolID)  // ARGV[1]
+
+	conn := r.pool.Get()
+	defer conn.Close()
+	if _, err := redisReapLocksScript.Do(conn, scriptArgs...); err != nil {
+		return err
 	}
 
 	return nil

--- a/dead_pool_reaper_test.go
+++ b/dead_pool_reaper_test.go
@@ -124,7 +124,7 @@ func TestDeadPoolReaperNoHeartbeat(t *testing.T) {
 	reaper := newDeadPoolReaper(ns, pool, []string{"type1"})
 	deadPools, err := reaper.findDeadPools()
 	assert.NoError(t, err)
-	assert.Equal(t, deadPools, map[string][]string{"1": {}, "2": {}, "3": {}})
+	assert.Equal(t, map[string][]string{"1": {}, "2": {}, "3": {}}, deadPools)
 
 	// Test requeueing jobs
 	_, err = conn.Do("lpush", redisKeyJobsInProgress(ns, "2", "type1"), "foo")

--- a/dead_pool_reaper_test.go
+++ b/dead_pool_reaper_test.go
@@ -326,8 +326,8 @@ func TestDeadPoolReaperCleanStaleLocks(t *testing.T) {
 	// clean lock info for workerPoolID1
 	reaper.cleanStaleLockInfo(workerPoolID1, jobNames)
 	assert.NoError(t, err)
-	assert.EqualValues(t, 2, getInt64(pool, lock1)) // job1 lock should be decr by 1
-	assert.EqualValues(t, 1, getInt64(pool, lock2)) // job2 lock is unchanged
+	assert.EqualValues(t, 2, getInt64(pool, lock1))   // job1 lock should be decr by 1
+	assert.EqualValues(t, 1, getInt64(pool, lock2))   // job2 lock is unchanged
 	v, _ := conn.Do("HGET", lockInfo1, workerPoolID1) // workerPoolID1 removed from job1's lock info
 	assert.Nil(t, v)
 

--- a/priority_sampler.go
+++ b/priority_sampler.go
@@ -13,15 +13,23 @@ type sampleItem struct {
 	priority uint
 
 	// payload:
-	redisJobs       string
-	redisJobsInProg string
+	redisJobs               string
+	redisJobsInProg         string
+	redisJobsPaused         string
+	redisJobsLock           string
+	redisJobsLockInfo       string
+	redisJobsMaxConcurrency string
 }
 
-func (s *prioritySampler) add(priority uint, redisJobs, redisJobsInProg string) {
+func (s *prioritySampler) add(priority uint, redisJobs, redisJobsInProg, redisJobsPaused, redisJobsLock, redisJobsLockInfo, redisJobsMaxConcurrency string) {
 	sample := sampleItem{
-		priority:        priority,
-		redisJobs:       redisJobs,
-		redisJobsInProg: redisJobsInProg,
+		priority:                priority,
+		redisJobs:               redisJobs,
+		redisJobsInProg:         redisJobsInProg,
+		redisJobsPaused:         redisJobsPaused,
+		redisJobsLock:           redisJobsLock,
+		redisJobsLockInfo:       redisJobsLockInfo,
+		redisJobsMaxConcurrency: redisJobsMaxConcurrency,
 	}
 	s.samples = append(s.samples, sample)
 	s.sum += priority

--- a/priority_sampler_test.go
+++ b/priority_sampler_test.go
@@ -8,9 +8,10 @@ import (
 
 func TestPrioritySampler(t *testing.T) {
 	ps := prioritySampler{}
-	ps.add(5, "jobs.5", "jobsinprog.5")
-	ps.add(2, "jobs.2a", "jobsinprog.2a")
-	ps.add(1, "jobs.1b", "jobsinprog.1b")
+
+	ps.add(5, "jobs.5", "jobsinprog.5", "jobspaused.5", "jobslock.5", "jobslockinfo.5", "jobsconcurrency.5")
+	ps.add(2, "jobs.2a", "jobsinprog.2a", "jobspaused.2a", "jobslock.2a", "jobslockinfo.2a", "jobsconcurrency.2a")
+	ps.add(1, "jobs.1b", "jobsinprog.1b", "jobspaused.1b", "jobslock.1b", "jobslockinfo.1b", "jobsconcurrency.1b")
 
 	var c5 = 0
 	var c2 = 0
@@ -41,7 +42,13 @@ func TestPrioritySampler(t *testing.T) {
 func BenchmarkPrioritySampler(b *testing.B) {
 	ps := prioritySampler{}
 	for i := 0; i < 200; i++ {
-		ps.add(uint(i)+1, "jobs."+fmt.Sprint(i), "jobsinprog."+fmt.Sprint(i))
+		ps.add(uint(i)+1,
+			"jobs."+fmt.Sprint(i),
+			"jobsinprog."+fmt.Sprint(i),
+			"jobspaused."+fmt.Sprint(i),
+			"jobslock."+fmt.Sprint(i),
+			"jobslockinfo."+fmt.Sprint(i),
+			"jobsmaxconcurrency."+fmt.Sprint(i))
 	}
 
 	b.ResetTimer()

--- a/redis.go
+++ b/redis.go
@@ -208,6 +208,7 @@ return nil`, redisLuaJobsPausedKey, redisLuaJobsLockKey, redisLuaJobsLockInfoKey
 // ...
 // KEYS[N] = the last job's in progress queue
 // KEYS[N+1] = the last job's job queue
+// ARGV[1] = workerPoolID for job queue
 var redisLuaReenqueueJob = fmt.Sprintf(`
 -- getLockKey inserted below
 %s

--- a/redis.go
+++ b/redis.go
@@ -146,11 +146,9 @@ for i=1,keylen,%d do
   maxConcurrency = tonumber(redis.call('get', concurrencyKey))
 
   if haveJobs(jobQueue) and not isPaused(pauseKey) and canRun(lockKey, maxConcurrency) then
+    acquireLock(lockKey, lockInfoKey, workerPoolID)
     res = redis.call('rpoplpush', jobQueue, inProgQueue)
-    if res then
-      acquireLock(lockKey, lockInfoKey, workerPoolID)
-      return {res, jobQueue, inProgQueue}
-    end
+    return {res, jobQueue, inProgQueue}
   end
 end
 return nil`, fetchKeysPerJobType)

--- a/redis.go
+++ b/redis.go
@@ -56,24 +56,20 @@ func redisKeyHeartbeat(namespace, workerPoolID string) string {
 	return redisNamespacePrefix(namespace) + "worker_pools:" + workerPoolID
 }
 
-var pauseKeySuffix = "paused"
 func redisKeyJobsPaused(namespace, jobName string) string {
-	return redisKeyJobs(namespace, jobName) + ":" + pauseKeySuffix
+	return redisKeyJobs(namespace, jobName) + ":paused"
 }
 
-var lockKeySuffix = "lock"
 func redisKeyJobsLock(namespace, jobName string) string {
-	return redisKeyJobs(namespace, jobName) + ":" + lockKeySuffix
+	return redisKeyJobs(namespace, jobName) + ":lock"
 }
 
-var lockInfoKeySuffix = "lock_info"
 func redisKeyJobsLockInfo(namespace, jobName string) string {
-	return redisKeyJobs(namespace, jobName) + ":" + lockInfoKeySuffix
+	return redisKeyJobs(namespace, jobName) + ":lock_info"
 }
 
-var concurrencyKeySuffix = "max_concurrency"
 func redisKeyJobsConcurrency(namespace, jobName string) string {
-	return redisKeyJobs(namespace, jobName) + ":" + concurrencyKeySuffix
+	return redisKeyJobs(namespace, jobName) + ":max_concurrency"
 }
 
 func redisKeyUniqueJob(namespace, jobName string, args map[string]interface{}) (string, error) {
@@ -98,43 +94,6 @@ func redisKeyLastPeriodicEnqueue(namespace string) string {
 	return redisNamespacePrefix(namespace) + "last_periodic_enqueue"
 }
 
-// Helpers functions used by Lua scripts below that need to match naming convention as redisKeyJobs* functions above
-// note: all assume the local var jobQueue is in scope, which is the the val of redisKeyJobs()
-// note: acquire/release lock functions assume getLockKey and getLockKeyInfo are in scope
-var redisLuaJobsPausedKey = fmt.Sprintf(`
-local function getPauseKey(jobQueue)
-  return string.format("%%s:%s", jobQueue)
-end`, pauseKeySuffix)
-
-var redisLuaJobsLockKey = fmt.Sprintf(`
-local function getLockKey(jobQueue)
-  return string.format("%%s:%s", jobQueue)
-end`, lockKeySuffix)
-
-var redisLuaJobsLockInfoKey = fmt.Sprintf(`
-local function getLockInfoKey(jobQueue)
-  return string.format("%%s:%s", jobQueue)
-end`, lockInfoKeySuffix)
-
-var redisLuaJobsConcurrencyKey = fmt.Sprintf(`
-local function getConcurrencyKey(jobQueue)
-  return string.format("%%s:%s", jobQueue)
-end`, concurrencyKeySuffix)
-
-var redisLuaAcquireLock = fmt.Sprintf(`
-local function acquireLock(jobQueue, workerPoolID)
-  redis.call('incr', getLockKey(jobQueue))
-  redis.call('hincrby', getLockInfoKey(jobQueue), workerPoolID, 1)
-end
-`)
-
-var redisLuaReleaseLock = fmt.Sprintf(`
-local function releaseLock(jobQueue, workerPoolID)
-  redis.call('decr', getLockKey(jobQueue))
-  redis.call('hincrby', getLockInfoKey(jobQueue), workerPoolID, -1)
-end
-`)
-
 // Used to fetch the next job to run
 //
 // KEYS[1] = the 1st job queue we want to try, eg, "work:jobs:emails"
@@ -146,16 +105,10 @@ end
 // KEYS[N+1] = the last job queue's in prog queue...
 // ARGV[1] = job queue's workerPoolID
 var redisLuaFetchJob = fmt.Sprintf(`
--- getPauseKey will be inserted below
-%s
--- getLockKey will be inserted below
-%s
--- getLockInfoKey will be inserted below
-%s
--- getConcurrencyKey will be inserted below
-%s
--- acquireLock will be inserted below
-%s
+local function acquireLock(lockKey, lockInfoKey, workerPoolID)
+  redis.call('incr', lockKey)
+  redis.call('hincrby', lockInfoKey, workerPoolID, 1)
+end
 
 local function haveJobs(jobQueue)
   return redis.call('llen', jobQueue) > 0
@@ -178,26 +131,29 @@ local function canRun(lockKey, maxConcurrency)
   end
 end
 
-local res, jobQueue, inProgQueue, pauseKey, lockKey, maxConcurrency, workerPoolID
+local res, jobQueue, inProgQueue, pauseKey, lockKey, maxConcurrency, workerPoolID, concurrencyKey, lockInfoKey
 local keylen = #KEYS
 workerPoolID = ARGV[1]
 
-for i=1,keylen,2 do
+for i=1,keylen,%d do
   jobQueue = KEYS[i]
   inProgQueue = KEYS[i+1]
-  pauseKey = getPauseKey(jobQueue)
-  lockKey = getLockKey(jobQueue)
-  maxConcurrency = tonumber(redis.call('get', getConcurrencyKey(jobQueue)))
+  pauseKey = KEYS[i+2]
+  lockKey = KEYS[i+3]
+  lockInfoKey = KEYS[i+4]
+  concurrencyKey = KEYS[i+5]
+
+  maxConcurrency = tonumber(redis.call('get', concurrencyKey))
 
   if haveJobs(jobQueue) and not isPaused(pauseKey) and canRun(lockKey, maxConcurrency) then
     res = redis.call('rpoplpush', jobQueue, inProgQueue)
     if res then
-      acquireLock(jobQueue, workerPoolID)
+      acquireLock(lockKey, lockInfoKey, workerPoolID)
       return {res, jobQueue, inProgQueue}
     end
   end
 end
-return nil`, redisLuaJobsPausedKey, redisLuaJobsLockKey, redisLuaJobsLockInfoKey, redisLuaJobsConcurrencyKey, redisLuaAcquireLock)
+return nil`, fetchKeysPerJobType)
 
 // Used by the reaper to re-enqueue jobs that were in progress
 //
@@ -210,26 +166,27 @@ return nil`, redisLuaJobsPausedKey, redisLuaJobsLockKey, redisLuaJobsLockInfoKey
 // KEYS[N+1] = the last job's job queue
 // ARGV[1] = workerPoolID for job queue
 var redisLuaReenqueueJob = fmt.Sprintf(`
--- getLockKey inserted below
-%s
--- getLockInfoKey will be inserted below
-%s
--- releaseLock will be inserted below
-%s
+local function releaseLock(lockKey, lockInfoKey, workerPoolID)
+  redis.call('decr', lockKey)
+  redis.call('hincrby', lockInfoKey, workerPoolID, -1)
+end
 
 local keylen = #KEYS
-local res, jobQueue, inProgQueue, workerPoolID
+local res, jobQueue, inProgQueue, workerPoolID, lockKey, lockInfoKey
 workerPoolID = ARGV[1]
-for i=1,keylen,2 do
+
+for i=1,keylen,%d do
   inProgQueue = KEYS[i]
   jobQueue = KEYS[i+1]
+  lockKey = KEYS[i+2]
+  lockInfoKey = KEYS[i+3]
   res = redis.call('rpoplpush', inProgQueue, jobQueue)
   if res then
-    releaseLock(jobQueue, workerPoolID)
+    releaseLock(lockKey, lockInfoKey, workerPoolID)
     return {res, inProgQueue, jobQueue}
   end
 end
-return nil`, redisLuaJobsLockKey, redisLuaJobsLockInfoKey, redisLuaReleaseLock)
+return nil`, requeueKeysPerJob)
 
 // Used by the reaper to clean up stale locks
 //
@@ -241,7 +198,7 @@ return nil`, redisLuaJobsLockKey, redisLuaJobsLockInfoKey, redisLuaReleaseLock)
 // KEYS[N] = the last job's lock
 // KEYS[N+1] = the last job's lock info haash
 // ARGV[1] = the dead worker pool id
-var redisLuaReapStaleLocks =  `
+var redisLuaReapStaleLocks = `
 local keylen = #KEYS
 local lock, lockInfo, deadLockCount
 local deadPoolID = ARGV[1]

--- a/redis.go
+++ b/redis.go
@@ -129,9 +129,9 @@ end
 `)
 
 var redisLuaReleaseLock = fmt.Sprintf(`
-local function releaseLock(jobQueue, workerPoolId)
+local function releaseLock(jobQueue, lockID)
   redis.call('decr', getLockKey(jobQueue))
-  redis.call('hincrby', getLockInfoKey(jobQueue), workerPoolId, -1)
+  redis.call('hincrby', getLockInfoKey(jobQueue), lockID, -1)
 end
 `)
 
@@ -167,7 +167,7 @@ local function isPaused(pauseKey)
   return redis.call('get', pauseKey)
 end
 
-local function canRun(lockKey, lockInfoKey, maxConcurrency)
+local function canRun(lockKey, maxConcurrency)
   local activeJobs = tonumber(redis.call('get', lockKey))
   if (not maxConcurrency or maxConcurrency == 0) or (not activeJobs or activeJobs < maxConcurrency) then
     -- default case: maxConcurrency not defined or set to 0 means no cap on concurrent jobs OR

--- a/redis.go
+++ b/redis.go
@@ -320,7 +320,7 @@ return requeuedCount
 `
 
 // KEYS[1] = job queue to push onto
-// KEYS[2] = Unique job's key. Test for existance and set if we push.
+// KEYS[2] = Unique job's key. Test for existence and set if we push.
 // ARGV[1] = job
 var redisLuaEnqueueUnique = `
 if redis.call('set', KEYS[2], '1', 'NX', 'EX', '86400') then

--- a/worker.go
+++ b/worker.go
@@ -104,7 +104,6 @@ func (w *worker) loop() {
 			timer.Reset(0)
 		case <-timer.C:
 			gotJob := true
-			jobsPerLoop := 1
 			for gotJob {
 				job, err := w.fetchJob()
 				if err != nil {
@@ -112,12 +111,6 @@ func (w *worker) loop() {
 					gotJob = false
 					timer.Reset(10 * time.Millisecond)
 				} else if job != nil {
-					fmt.Printf("worker %v Fetched job num %v -- %v\n", w.workerID, jobsPerLoop, job)
-					jobsPerLoop++
-					if jobsPerLoop > 1 {
-
-
-					}
 					w.processJob(job)
 					consequtiveNoJobs = 0
 				} else {
@@ -131,7 +124,6 @@ func (w *worker) loop() {
 					if idx >= int64(len(sleepBackoffsInMilliseconds)) {
 						idx = int64(len(sleepBackoffsInMilliseconds)) - 1
 					}
-					// fmt.Printf("Jobs per loop=%v -- worker id=%v\n", jobsPerLoop, w.workerID)
 					timer.Reset(time.Duration(sleepBackoffsInMilliseconds[idx]) * time.Millisecond)
 				}
 			}

--- a/worker_pool.go
+++ b/worker_pool.go
@@ -234,7 +234,7 @@ func (wp *WorkerPool) startRequeuers() {
 	}
 	wp.retrier = newRequeuer(wp.namespace, wp.pool, redisKeyRetry(wp.namespace), jobNames)
 	wp.scheduler = newRequeuer(wp.namespace, wp.pool, redisKeyScheduled(wp.namespace), jobNames)
-	wp.deadPoolReaper = newDeadPoolReaper(wp.namespace, wp.pool)
+	wp.deadPoolReaper = newDeadPoolReaper(wp.namespace, wp.pool, jobNames)
 	wp.retrier.start()
 	wp.scheduler.start()
 	wp.deadPoolReaper.start()

--- a/worker_pool_test.go
+++ b/worker_pool_test.go
@@ -118,7 +118,7 @@ func TestWorkersPoolRunSingleThreaded(t *testing.T) {
 	pool := newTestPool(":6379")
 	ns := "work"
 	job1 := "job1"
-	numJobs, concurrency, sleepTime := 5, 5, 1000
+	numJobs, concurrency, sleepTime := 5, 5, 2
 	wp := setupTestWorkerPool(pool, ns, job1, concurrency, JobOptions{Priority: 1, MaxConcurrency: 1})
 	wp.Start()
 	// enqueue some jobs
@@ -127,18 +127,20 @@ func TestWorkersPoolRunSingleThreaded(t *testing.T) {
 		_, err := enqueuer.Enqueue(job1, Q{"sleep": sleepTime})
 		assert.Nil(t, err)
 	}
+
+	// make sure we've enough jobs queued up to make an interesting test
 	jobsQueued := listSize(pool, redisKeyJobs(ns, job1))
-	// make sure we've some jobs queued up
-	assert.True(t, jobsQueued > 1, "should be %v jobs queued up, but only found %v", numJobs, jobsQueued)
+	assert.True(t, jobsQueued > 3, "should be at least 3 jobs queued up, but only found %v", jobsQueued)
 
 	// now make sure the during the duration of job execution there is never > 1 job in flight
-	// wp.Start()
 	start := time.Now()
 	totalRuntime := time.Duration(sleepTime * numJobs) * time.Millisecond
+	time.Sleep(10 * time.Millisecond)
 	for time.Since(start) < totalRuntime {
+		// jobs in progress, lock count for the job and lock info for the pool should never exceed 1
 		jobsInProgress := listSize(pool, redisKeyJobsInProgress(ns, wp.workerPoolID, job1))
 		assert.True(t, jobsInProgress <= 1, "jobsInProgress should never exceed 1: actual=%d", jobsInProgress)
-		// lock count for the job and lock info for the pool should never exceed 1
+
 		jobLockCount := getInt64(pool, redisKeyJobsLock(ns, job1))
 		assert.True(t, jobLockCount <= 1, "global lock count for job should never exceed 1, got: %v", jobLockCount)
 		wpLockCount := hgetInt64(pool, redisKeyJobsLockInfo(ns, job1), wp.workerPoolID)
@@ -167,13 +169,17 @@ func TestWorkerPoolPauseSingleThreadedJobs(t *testing.T) {
 		_, err := enqueuer.Enqueue(job1, Q{"sleep": sleepTime})
 		assert.Nil(t, err)
 	}
-	// allow time for a job to start
-	time.Sleep(1 * time.Millisecond)
-	// pause work and allow time for any outstanding jobs to finish
+	// provide time for jobs to process
+	time.Sleep(10 * time.Millisecond)
+
+	// pause work, provide time for outstanding jobs to finish and queue up another job
 	pauseJobs(ns, job1, pool)
 	time.Sleep(2 * time.Millisecond)
+	_, err := enqueuer.Enqueue(job1, Q{"sleep": sleepTime})
+	assert.Nil(t, err)
+
 	// check that we still have some jobs to process
-	assert.True(t, listSize(pool, redisKeyJobs(ns, job1)) > int64(0))
+	assert.True(t, listSize(pool, redisKeyJobs(ns, job1)) >= 1)
 
 	// now make sure no jobs get started until we unpause
 	start := time.Now()
@@ -208,10 +214,9 @@ func (t *TestContext) SleepyJob(job *Job) error {
 }
 
 func setupTestWorkerPool(pool *redis.Pool, namespace, jobName string, concurrency int, jobOpts JobOptions) *WorkerPool {
-	cleanKeyspace(namespace, pool)
-	//deleteQueue(pool, namespace, jobName)
-	//deleteRetryAndDead(pool, namespace)
-	//deletePausedAndLockedKeys(namespace, jobName, pool)
+	deleteQueue(pool, namespace, jobName)
+	deleteRetryAndDead(pool, namespace)
+	deletePausedAndLockedKeys(namespace, jobName, pool)
 
 	wp := NewWorkerPool(TestContext{}, uint(concurrency), namespace, pool)
 	wp.JobWithOptions(jobName, jobOpts, (*TestContext).SleepyJob)

--- a/worker_pool_test.go
+++ b/worker_pool_test.go
@@ -118,9 +118,8 @@ func TestWorkersPoolRunSingleThreaded(t *testing.T) {
 	pool := newTestPool(":6379")
 	ns := "work"
 	job1 := "job1"
-	numJobs, concurrency, sleepTime := 5, 5, 2
+	numJobs, concurrency, sleepTime := 5, 5, 1000
 	wp := setupTestWorkerPool(pool, ns, job1, concurrency, JobOptions{Priority: 1, MaxConcurrency: 1})
-
 	wp.Start()
 	// enqueue some jobs
 	enqueuer := NewEnqueuer(ns, pool)
@@ -128,14 +127,22 @@ func TestWorkersPoolRunSingleThreaded(t *testing.T) {
 		_, err := enqueuer.Enqueue(job1, Q{"sleep": sleepTime})
 		assert.Nil(t, err)
 	}
-	assert.True(t, int64(numJobs) >= listSize(pool, redisKeyJobs(ns, job1)))
+	jobsQueued := listSize(pool, redisKeyJobs(ns, job1))
+	// make sure we've some jobs queued up
+	assert.True(t, jobsQueued > 1, "should be %v jobs queued up, but only found %v", numJobs, jobsQueued)
 
 	// now make sure the during the duration of job execution there is never > 1 job in flight
+	// wp.Start()
 	start := time.Now()
 	totalRuntime := time.Duration(sleepTime * numJobs) * time.Millisecond
 	for time.Since(start) < totalRuntime {
 		jobsInProgress := listSize(pool, redisKeyJobsInProgress(ns, wp.workerPoolID, job1))
-		assert.True(t, jobsInProgress <= 1, fmt.Sprintf("jobsInProgress should never exceed 1: actual=%d", jobsInProgress))
+		assert.True(t, jobsInProgress <= 1, "jobsInProgress should never exceed 1: actual=%d", jobsInProgress)
+		// lock count for the job and lock info for the pool should never exceed 1
+		jobLockCount := getInt64(pool, redisKeyJobsLock(ns, job1))
+		assert.True(t, jobLockCount <= 1, "global lock count for job should never exceed 1, got: %v", jobLockCount)
+		wpLockCount := hgetInt64(pool, redisKeyJobsLockInfo(ns, job1), wp.workerPoolID)
+		assert.True(t, wpLockCount <= 1, "lock count for the worker pool should never exceed 1: actual=%v", wpLockCount)
 		time.Sleep(time.Duration(sleepTime) * time.Millisecond)
 	}
 	wp.Drain()
@@ -144,6 +151,8 @@ func TestWorkersPoolRunSingleThreaded(t *testing.T) {
 	// At this point it should all be empty.
 	assert.EqualValues(t, 0, listSize(pool, redisKeyJobs(ns, job1)))
 	assert.EqualValues(t, 0, listSize(pool, redisKeyJobsInProgress(ns, wp.workerPoolID, job1)))
+	assert.EqualValues(t, 0, getInt64(pool, redisKeyJobsLock(ns, job1)))
+	assert.EqualValues(t, 0, hgetInt64(pool, redisKeyJobsLockInfo(ns, job1), wp.workerPoolID))
 }
 
 func TestWorkerPoolPauseSingleThreadedJobs(t *testing.T) {
@@ -151,9 +160,6 @@ func TestWorkerPoolPauseSingleThreadedJobs(t *testing.T) {
 	ns, job1 := "work", "job1"
 	numJobs, concurrency, sleepTime := 5, 5, 2
 	wp := setupTestWorkerPool(pool, ns, job1, concurrency, JobOptions{Priority: 1, MaxConcurrency: 1})
-	// reset the backoff times to help with testing
-	sleepBackoffsInMilliseconds = []int64{10, 10, 10, 10, 10}
-
 	wp.Start()
 	// enqueue some jobs
 	enqueuer := NewEnqueuer(ns, pool)
@@ -161,11 +167,11 @@ func TestWorkerPoolPauseSingleThreadedJobs(t *testing.T) {
 		_, err := enqueuer.Enqueue(job1, Q{"sleep": sleepTime})
 		assert.Nil(t, err)
 	}
-	assert.True(t, int64(numJobs) >= listSize(pool, redisKeyJobs(ns, job1)))
-
+	// allow time for a job to start
+	time.Sleep(1 * time.Millisecond)
 	// pause work and allow time for any outstanding jobs to finish
 	pauseJobs(ns, job1, pool)
-	time.Sleep(time.Duration(sleepTime * 2) * time.Millisecond)
+	time.Sleep(2 * time.Millisecond)
 	// check that we still have some jobs to process
 	assert.True(t, listSize(pool, redisKeyJobs(ns, job1)) > int64(0))
 
@@ -174,6 +180,9 @@ func TestWorkerPoolPauseSingleThreadedJobs(t *testing.T) {
 	totalRuntime := time.Duration(sleepTime * numJobs) * time.Millisecond
 	for time.Since(start) < totalRuntime {
 		assert.EqualValues(t, 0, listSize(pool, redisKeyJobsInProgress(ns, wp.workerPoolID, job1)))
+		// lock count for the job and lock info for the pool should both be at 1 while job is running
+		assert.EqualValues(t, 0, getInt64(pool, redisKeyJobsLock(ns, job1)))
+		assert.EqualValues(t, 0, hgetInt64(pool, redisKeyJobsLockInfo(ns, job1), wp.workerPoolID))
 		time.Sleep(time.Duration(sleepTime) * time.Millisecond)
 	}
 
@@ -187,6 +196,8 @@ func TestWorkerPoolPauseSingleThreadedJobs(t *testing.T) {
 	// At this point it should all be empty.
 	assert.EqualValues(t, 0, listSize(pool, redisKeyJobs(ns, job1)))
 	assert.EqualValues(t, 0, listSize(pool, redisKeyJobsInProgress(ns, wp.workerPoolID, job1)))
+	assert.EqualValues(t, 0, getInt64(pool, redisKeyJobsLock(ns, job1)))
+	assert.EqualValues(t, 0, hgetInt64(pool, redisKeyJobsLockInfo(ns, job1), wp.workerPoolID))
 }
 
 // Test Helpers
@@ -197,11 +208,14 @@ func (t *TestContext) SleepyJob(job *Job) error {
 }
 
 func setupTestWorkerPool(pool *redis.Pool, namespace, jobName string, concurrency int, jobOpts JobOptions) *WorkerPool {
-	deleteQueue(pool, namespace, jobName)
-	deleteRetryAndDead(pool, namespace)
-	deletePausedAndLockedKeys(namespace, jobName, pool)
+	cleanKeyspace(namespace, pool)
+	//deleteQueue(pool, namespace, jobName)
+	//deleteRetryAndDead(pool, namespace)
+	//deletePausedAndLockedKeys(namespace, jobName, pool)
 
 	wp := NewWorkerPool(TestContext{}, uint(concurrency), namespace, pool)
 	wp.JobWithOptions(jobName, jobOpts, (*TestContext).SleepyJob)
+	// reset the backoff times to help with testing
+	sleepBackoffsInMilliseconds = []int64{10, 10, 10, 10, 10}
 	return wp
 }

--- a/worker_pool_test.go
+++ b/worker_pool_test.go
@@ -134,7 +134,7 @@ func TestWorkersPoolRunSingleThreaded(t *testing.T) {
 
 	// now make sure the during the duration of job execution there is never > 1 job in flight
 	start := time.Now()
-	totalRuntime := time.Duration(sleepTime * numJobs) * time.Millisecond
+	totalRuntime := time.Duration(sleepTime*numJobs) * time.Millisecond
 	time.Sleep(10 * time.Millisecond)
 	for time.Since(start) < totalRuntime {
 		// jobs in progress, lock count for the job and lock info for the pool should never exceed 1
@@ -183,7 +183,7 @@ func TestWorkerPoolPauseSingleThreadedJobs(t *testing.T) {
 
 	// now make sure no jobs get started until we unpause
 	start := time.Now()
-	totalRuntime := time.Duration(sleepTime * numJobs) * time.Millisecond
+	totalRuntime := time.Duration(sleepTime*numJobs) * time.Millisecond
 	for time.Since(start) < totalRuntime {
 		assert.EqualValues(t, 0, listSize(pool, redisKeyJobsInProgress(ns, wp.workerPoolID, job1)))
 		// lock count for the job and lock info for the pool should both be at 1 while job is running


### PR DESCRIPTION
Creates a new lock_info hash that is used to reset job lock state if dead worker pools were killed while holding a lock.

Some design considerations/motivations:
* Stale lock reaping happens _after_ reenqueuing, which also updates lock info
* If heartbeat has expired, we pass the current set of job names so that lock reaping can happen for jobs currently running
* A new lua script called `redisLuaReapStaleLocks` has been added so lock reaping can happen atomically
* Explicitly pass KEYS into the lua scripts as to not break clustered redis configurations

Todo:
- [x] fix that blasted failing `TestDeadPoolReaperNoHeartbeat` test