### PR TITLE
Fix infinite worker loop preventing shutdown when Stop() called

### DIFF
--- a/worker_test.go
+++ b/worker_test.go
@@ -3,10 +3,12 @@ package work
 import (
 	"fmt"
 	"strconv"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/garyburd/redigo/redis"
+	"github.com/gocraft/work"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -546,4 +548,47 @@ func deletePausedAndLockedKeys(namespace, jobName string, pool *redis.Pool) erro
 		return err
 	}
 	return nil
+}
+
+type emptyCtx struct{}
+
+// Starts up a pool with two workers emptying it as fast as they can
+// The pool is Stop()ped while jobs are still going on.  Tests that the
+// pool processing is really stopped and that it's not first completely
+// drained before returning.
+// https://github.com/gocraft/work/issues/24
+func TestWorkerPoolStop(t *testing.T) {
+	ns := "will_it_end"
+	pool := newTestPool(":6379")
+	var started, stopped int32
+	num_iters := 30
+
+	wp := NewWorkerPool(emptyCtx{}, 2, ns, pool)
+
+	wp.Job("sample_job", func(c *emptyCtx, job *Job) error {
+		atomic.AddInt32(&started, 1)
+		time.Sleep(1 * time.Second)
+		atomic.AddInt32(&stopped, 1)
+		return nil
+	})
+
+	var enqueuer = work.NewEnqueuer(ns, pool)
+
+	for i := 0; i <= num_iters; i++ {
+		enqueuer.Enqueue("sample_job", work.Q{})
+	}
+
+	// Start the pool and quit before it has had a chance to complete
+	// all the jobs.
+	wp.Start()
+	time.Sleep(5 * time.Second)
+	wp.Stop()
+
+	if started != stopped {
+		t.Errorf("Expected that jobs were finished and not killed while processing (started=%d, stopped=%d)", started, stopped)
+	}
+
+	if started >= int32(num_iters) {
+		t.Errorf("Expected that jobs queue was not completely emptied.")
+	}
 }

--- a/worker_test.go
+++ b/worker_test.go
@@ -352,7 +352,7 @@ func TestWorkersPaused(t *testing.T) {
 func TestStop(t *testing.T) {
 	redisPool := &redis.Pool{
 		Dial: func() (redis.Conn, error) {
-			c, err := redis.Dial("tcp", "notworking:6379")
+			c, err := redis.Dial("tcp", "notworking:6379", redis.DialConnectTimeout(1*time.Second))
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
The job fetch routine implements an infinite loop that pulls jobs as long as there are jobs to pull. If a backlog of jobs exists in the queue, and `Stop()` is called, the worker never terminates. This will cause a program that is attempting to terminate to run indefinitely.

This PR fixes the infinite loop and respects the `<-timer.C` call in the select loop instead, giving the `stopChan` and `drainChan` a chance to fire. Tests are provided to validate this issue is fixed.

In addition, it fixes an issue with a test that hangs indefinitely if it cannot connect to redis.

This PR was, for the most part, already proposed, and much code was taken from that PR. I am submitting this PR to keep my fork in sync as I intend to send additional PRs in the future.