### PR TITLE
BUGFIX: Reap immediately after initialization on startup

### DIFF
--- a/heartbeater_test.go
+++ b/heartbeater_test.go
@@ -8,13 +8,6 @@ import (
 	"time"
 )
 
-func TestHeartBeatExpiration(t *testing.T) {
-	// just to make sure -- heartbeats should not expire before the reaper has had a chance to assess whether or
-	// not jobs are dead (in the event of a dirty shutdown, for example)
-	assert.True(t, heartbeatExpiration > deadTime)
-	assert.True(t, heartbeatExpiration > reapPeriod + reapJitterSecs * time.Second)
-}
-
 func TestHeartbeater(t *testing.T) {
 	pool := newTestPool(":6379")
 	ns := "work"


### PR DESCRIPTION
Possible fix for #55. 

These changes allow the first reap cycle to cleanup dead pools and any associated stale lock info. 2 main changes:

- shorten the `deadTime` from 5 minutes to 10 seconds (2X heartbeat period) 
- first reap cycle begins after some initialization time during process startup (currently `deadTime`, or 10 seconds) 
- don't expire heartbeat keys ever, which delegates this responsibility to the reaper