### PR TITLE
Add support for chaining tasks

### DIFF
--- a/enqueue_test.go
+++ b/enqueue_test.go
@@ -51,6 +51,59 @@ func TestEnqueue(t *testing.T) {
 	assert.EqualValues(t, 2, listSize(pool, redisKeyJobs(ns, "wat")))
 }
 
+func TestEnqueueChain(t *testing.T) {
+	pool := newTestPool(":6379")
+	ns := "work"
+	cleanKeyspace(ns, pool)
+	enqueuer := NewEnqueuer(ns, pool)
+	job, err := enqueuer.EnqueueChain(C{T{"foo": Q{"a": 1, "b": "red"}}, T{"bar": Q{"a": 2, "b": "blue"}}})
+	assert.Nil(t, err)
+	assert.Equal(t, "foo", job.Name)
+	assert.True(t, len(job.ID) > 10)                        // Something is in it
+	assert.True(t, job.EnqueuedAt > (time.Now().Unix()-10)) // Within 10 seconds
+	assert.True(t, job.EnqueuedAt < (time.Now().Unix()+10)) // Within 10 seconds
+	assert.Equal(t, "red", job.ArgString("b"))
+	assert.EqualValues(t, 1, job.ArgInt64("a"))
+	assert.NoError(t, job.ArgError())
+
+	// Make sure second job is in OnSuccess
+	assert.Equal(t, "bar", job.OnSuccess.Name)
+	assert.Equal(t, "blue", job.OnSuccess.ArgString("b"))
+	assert.EqualValues(t, 2, job.OnSuccess.ArgInt64("a"))
+	assert.NoError(t, job.OnSuccess.ArgError())
+
+	// Make sure "foo" is in the known jobs
+	assert.EqualValues(t, []string{"foo"}, knownJobs(pool, redisKeyKnownJobs(ns)))
+
+	// Make sure the cache is set
+	expiresAt := enqueuer.knownJobs["foo"]
+	assert.True(t, expiresAt > (time.Now().Unix()+290))
+
+	// Make sure the length of the queue is 1
+	assert.EqualValues(t, 1, listSize(pool, redisKeyJobs(ns, "foo")))
+
+	// Get the job
+	j := jobOnQueue(pool, redisKeyJobs(ns, "foo"))
+	assert.Equal(t, "foo", j.Name)
+	assert.True(t, len(j.ID) > 10)                        // Something is in it
+	assert.True(t, j.EnqueuedAt > (time.Now().Unix()-10)) // Within 10 seconds
+	assert.True(t, j.EnqueuedAt < (time.Now().Unix()+10)) // Within 10 seconds
+	assert.Equal(t, "red", j.ArgString("b"))
+	assert.EqualValues(t, 1, j.ArgInt64("a"))
+	assert.NoError(t, j.ArgError())
+	// Make sure second job is in OnSuccess
+	assert.Equal(t, "bar", j.OnSuccess.Name)
+	assert.Equal(t, "blue", j.OnSuccess.ArgString("b"))
+	assert.EqualValues(t, 2, j.OnSuccess.ArgInt64("a"))
+	assert.NoError(t, j.OnSuccess.ArgError())
+
+	// Now enqueue another job, make sure that we can enqueue multiple
+	_, err = enqueuer.EnqueueChain(C{T{"foo": Q{"a": 1, "b": "red"}}, T{"bar": Q{"a": 2, "b": "blue"}}})
+	_, err = enqueuer.EnqueueChain(C{T{"foo": Q{"a": 1, "b": "red"}}, T{"bar": Q{"a": 2, "b": "blue"}}})
+	assert.Nil(t, err)
+	assert.EqualValues(t, 2, listSize(pool, redisKeyJobs(ns, "foo")))
+}
+
 func TestEnqueueIn(t *testing.T) {
 	pool := newTestPool(":6379")
 	ns := "work"

--- a/job.go
+++ b/job.go
@@ -26,11 +26,21 @@ type Job struct {
 	inProgQueue  []byte
 	argError     error
 	observer     *observer
+
+	OnSuccess *Job `json:"on_success,omitempy"`
 }
 
 // Q is a shortcut to easily specify arguments for jobs when enqueueing them.
 // Example: e.Enqueue("send_email", work.Q{"addr": "test@example.com", "track": true})
 type Q map[string]interface{}
+
+// T is a shortcut to easily specify tasks along with their arguments.
+// Example: T{"job": Q{"arg": "foo"}}
+type T map[string]Q
+
+// C is a shortcut to easily specify chains of tasks along with their arguments.
+// Example: e.EnqueueChain(work.C{"job1": work.Q{"arg": "foo"}, "job2": work.Q{"arg": "bar"}})
+type C []map[string]Q
 
 func newJob(rawJSON, dequeuedFrom, inProgQueue []byte) (*Job, error) {
 	var job Job


### PR DESCRIPTION
As proposed in #60 this adds support for chaining tasks. With this PR it's possible to create chains of tasks that are processed one after another:

```go
_, err := e.EnqueueChain(work.C{
    work.T{"job1": work.Q{
        "arg1": "foo",
    }},
    work.T{"job2": work.Q{
        "arg1": "foo",
        "arg2": "bar",
    }},
    work.T{"job3": work.Q{
        "arg1": "foo",
    }},
})
```