### PR TITLE
periodicEnqueuerSleep is divided by Minute, should be Second?

### DIFF
--- a/periodic_enqueuer.go
+++ b/periodic_enqueuer.go
@@ -133,7 +133,7 @@ func (pe *periodicEnqueuer) shouldEnqueue() bool {
 		return true
 	}
 
-	return lastEnqueue < (nowEpochSeconds() - int64(periodicEnqueuerSleep/time.Minute))
+	return lastEnqueue < (nowEpochSeconds() - int64(periodicEnqueuerSleep/time.Second))
 }
 
 func makeUniquePeriodicID(name, spec string, epoch int64) string {

--- a/periodic_enqueuer_test.go
+++ b/periodic_enqueuer_test.go
@@ -91,7 +91,7 @@ func TestPeriodicEnqueuer(t *testing.T) {
 
 	assert.False(t, pe.shouldEnqueue())
 
-	setNowEpochSecondsMock(1468359454 + int64(periodicEnqueuerSleep/time.Minute) + 10)
+	setNowEpochSecondsMock(1468359454 + int64(periodicEnqueuerSleep/time.Second) + 10)
 
 	assert.True(t, pe.shouldEnqueue())
 }


### PR DESCRIPTION
Hi, this seems to be a bug to me, but I'm not sure.
In `return lastEnqueue < (nowEpochSeconds() - int64(periodicEnqueuerSleep/time.Minute))`,
both `lastEnqueue ` and `nowEpochSeconds()` are in "second", but the result of `periodicEnqueuerSleep/time.Minute` is 2 "minute", they are of different units.