### PR TITLE
remove 5000 from backoff

### DIFF
--- a/worker.go
+++ b/worker.go
@@ -92,7 +92,7 @@ func (w *worker) drain() {
 	w.observer.drain()
 }
 
-var sleepBackoffsInMilliseconds = []int64{0, 10, 100, 1000, 5000}
+var sleepBackoffsInMilliseconds = []int64{0, 10, 100, 1000}
 
 func (w *worker) loop() {
 	var drained bool


### PR DESCRIPTION
I'm testing feature "Scheduled Jobs", I find that sometimes if I enqueue a job "in 2s", the job is not ran "in 2s", but "in 5s".
Then I look into code, it's caused by the "5000 milliseconds backoff".
For example:
At ts=0s, all workers executed `timer.Reset(5 seconds)` in `loop()`.
At ts=1s, I enquque a job which is scheduled "in 2s".
At ts=3s, all workers are blocked, job is not ran as scheduled.
At ts=5s, all workers wake up, one of them fetches the scheduled job, then `processJob()`.

I think we should remove "5000" for backoff list, the max duration for a backoff should be 1999ms (<2 seconds).