### PR TITLE
Add job specified middleware chain

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -246,6 +246,7 @@ func TestClientRetryJobs(t *testing.T) {
 
 	wp := NewWorkerPool(TestContext{}, 10, ns, pool)
 	wp.Job("wat", func(job *Job) error {
+		job.Failed(fmt.Errorf("ohno"))
 		return fmt.Errorf("ohno")
 	})
 	wp.Start()
@@ -285,6 +286,7 @@ func TestClientDeadJobs(t *testing.T) {
 
 	wp := NewWorkerPool(TestContext{}, 10, ns, pool)
 	wp.JobWithOptions("wat", JobOptions{Priority: 1, MaxFails: 1}, func(job *Job) error {
+		job.Failed(fmt.Errorf("ohno"))
 		return fmt.Errorf("ohno")
 	})
 	wp.Start()
@@ -664,6 +666,7 @@ func TestClientDeleteRetryJob(t *testing.T) {
 
 	wp := NewWorkerPool(TestContext{}, 10, ns, pool)
 	wp.Job("wat", func(job *Job) error {
+		job.Failed(fmt.Errorf("ohno"))
 		return fmt.Errorf("ohno")
 	})
 	wp.Start()

--- a/redis.go
+++ b/redis.go
@@ -232,7 +232,7 @@ if #res > 0 then
   queue = ARGV[1] .. j['name']
   for _,v in pairs(KEYS) do
     if v == queue then
-      j['t'] = tonumber(ARGV[2])
+      j['enqueued_at'] = tonumber(ARGV[2])
       redis.call('lpush', queue, cjson.encode(j))
       return 'ok'
     end
@@ -288,7 +288,7 @@ for i=1,jobCount do
     found = false
     for _,v in pairs(KEYS) do
       if v == queue then
-        j['t'] = tonumber(ARGV[2])
+        j['enqueued_at'] = tonumber(ARGV[2])
         j['fails'] = nil
         j['failed_at'] = nil
         j['err'] = nil
@@ -326,7 +326,7 @@ for i=1,jobCount do
   found = false
   for _,v in pairs(KEYS) do
     if v == queue then
-      j['t'] = tonumber(ARGV[2])
+      j['enqueued_at'] = tonumber(ARGV[2])
       j['fails'] = nil
       j['failed_at'] = nil
       j['err'] = nil

--- a/run.go
+++ b/run.go
@@ -19,7 +19,6 @@ func runJob(job *Job, ctxType reflect.Type, middleware []*middlewareHandler, jt 
 
 	var next NextMiddlewareFunc
 	next = func() error {
-
 		if currentMiddleware < maxMiddleware {
 			mw := middleware[currentMiddleware]
 			currentMiddleware++

--- a/run_test.go
+++ b/run_test.go
@@ -53,6 +53,131 @@ func TestRunBasicMiddleware(t *testing.T) {
 	assert.Equal(t, "mw1mw2mw3h1foo", c.String())
 }
 
+func TestRunJobMiddleware(t *testing.T) {
+	jmw1 := func(j *Job, next NextMiddlewareFunc) error {
+		j.setArg("jmw1", "jmw1")
+		return next()
+	}
+
+	jmw2 := func(c *tstCtx, j *Job, next NextMiddlewareFunc) error {
+		c.record(j.Args["jmw1"].(string))
+		c.record("jmw2")
+		next()
+		c.record("jmw2")
+		return nil
+	}
+
+	jmw3 := func(c *tstCtx, j *Job, next NextMiddlewareFunc) error {
+		c.record("jmw3")
+		next()
+		c.record("jmw3")
+		return nil
+	}
+
+	h1 := func(c *tstCtx, j *Job) error {
+		c.record("h1")
+		c.record(j.Args["a"].(string))
+		return nil
+	}
+
+	jobMiddleware := []*middlewareHandler{
+		{IsGeneric: true, GenericMiddlewareHandler: jmw1},
+		{IsGeneric: false, DynamicMiddleware: reflect.ValueOf(jmw2)},
+		{IsGeneric: false, DynamicMiddleware: reflect.ValueOf(jmw3)},
+	}
+
+	jt := &jobType{
+		Name:           "foo",
+		IsGeneric:      false,
+		DynamicHandler: reflect.ValueOf(h1),
+		middleware:     jobMiddleware,
+	}
+
+	job := &Job{
+		Name: "foo",
+		Args: map[string]interface{}{"a": "foo"},
+	}
+
+	v, err := runJob(job, tstCtxType, nil, jt)
+	assert.NoError(t, err)
+	c := v.Interface().(*tstCtx)
+	assert.Equal(t, "jmw1jmw2jmw3h1foojmw3jmw2", c.String())
+}
+
+func TestRunBasicAndJobMiddleware(t *testing.T) {
+	mw1 := func(j *Job, next NextMiddlewareFunc) error {
+		j.setArg("mw1", "mw1")
+		return next()
+	}
+
+	mw2 := func(c *tstCtx, j *Job, next NextMiddlewareFunc) error {
+		c.record(j.Args["mw1"].(string))
+		c.record("mw2")
+		next()
+		c.record("mw2")
+		return nil
+	}
+
+	mw3 := func(c *tstCtx, j *Job, next NextMiddlewareFunc) error {
+		next()
+		c.record("mw3")
+		return nil
+	}
+
+	jmw1 := func(j *Job, next NextMiddlewareFunc) error {
+		j.setArg("jmw1", "jmw1")
+		return next()
+	}
+
+	jmw2 := func(c *tstCtx, j *Job, next NextMiddlewareFunc) error {
+		c.record(j.Args["jmw1"].(string))
+		c.record("jmw2")
+		next()
+		c.record("jmw2")
+		return nil
+	}
+
+	jmw3 := func(c *tstCtx, j *Job, next NextMiddlewareFunc) error {
+		c.record("jmw3")
+		return next()
+	}
+
+	h1 := func(c *tstCtx, j *Job) error {
+		c.record("h1")
+		c.record(j.Args["a"].(string))
+		return nil
+	}
+
+	middleware := []*middlewareHandler{
+		{IsGeneric: true, GenericMiddlewareHandler: mw1},
+		{IsGeneric: false, DynamicMiddleware: reflect.ValueOf(mw2)},
+		{IsGeneric: false, DynamicMiddleware: reflect.ValueOf(mw3)},
+	}
+
+	jobMiddleware := []*middlewareHandler{
+		{IsGeneric: true, GenericMiddlewareHandler: jmw1},
+		{IsGeneric: false, DynamicMiddleware: reflect.ValueOf(jmw2)},
+		{IsGeneric: false, DynamicMiddleware: reflect.ValueOf(jmw3)},
+	}
+
+	jt := &jobType{
+		Name:           "foo",
+		IsGeneric:      false,
+		DynamicHandler: reflect.ValueOf(h1),
+		middleware:     jobMiddleware,
+	}
+
+	job := &Job{
+		Name: "foo",
+		Args: map[string]interface{}{"a": "foo"},
+	}
+
+	v, err := runJob(job, tstCtxType, middleware, jt)
+	assert.NoError(t, err)
+	c := v.Interface().(*tstCtx)
+	assert.Equal(t, "mw1mw2jmw1jmw2jmw3h1foojmw2mw3mw2", c.String())
+}
+
 func TestRunHandlerError(t *testing.T) {
 	mw1 := func(j *Job, next NextMiddlewareFunc) error {
 		return next()

--- a/worker.go
+++ b/worker.go
@@ -193,7 +193,8 @@ func (w *worker) processJob(job *Job) {
 		_, runErr := runJob(job, w.contextType, w.middleware, jt)
 		w.observeDone(job.Name, job.ID, runErr)
 		if runErr != nil {
-			job.failed(runErr)
+			// NOTE: set job failed in middleware, comment this line
+			// job.Failed(runErr)
 			w.addToRetryOrDead(jt, job, runErr)
 		} else {
 			w.removeJobFromInProgress(job)
@@ -202,7 +203,7 @@ func (w *worker) processJob(job *Job) {
 		// NOTE: since we don't have a jobType, we don't know max retries
 		runErr := fmt.Errorf("stray job: no handler")
 		logError("process_job.stray", runErr)
-		job.failed(runErr)
+		job.Failed(runErr)
 		w.addToDead(job, runErr)
 	}
 }

--- a/worker_pool.go
+++ b/worker_pool.go
@@ -96,49 +96,18 @@ func NewWorkerPool(ctx interface{}, concurrency uint, namespace string, pool *re
 	return wp
 }
 
-// JobMiddleware appends the specified function to the Job specified middleware chain. The fn can take one of these forms:
-// (*ContextType).func(*Job, NextMiddlewareFunc) error, (ContextType matches the type of ctx specified when creating a pool)
-// func(*Job, NextMiddlewareFunc) error, for the generic middleware format.
-func (wp *WorkerPool) JobMiddleware(jobName string, fn interface{}) *WorkerPool {
-	vfn := reflect.ValueOf(fn)
-	validateMiddlewareType(wp.contextType, vfn)
-
-	jt := wp.jobTypes[jobName]
-	if jt == nil {
-		return wp
-	}
-
-	jmw := &middlewareHandler{
-		DynamicMiddleware: vfn,
-	}
-
-	if gmh, ok := fn.(func(*Job, NextMiddlewareFunc) error); ok {
-		jmw.IsGeneric = true
-		jmw.GenericMiddlewareHandler = gmh
-	}
-
-	jt.middleware = append(jt.middleware, jmw)
-
-	return wp
-}
-
 // Middleware appends the specified function to the middleware chain. The fn can take one of these forms:
 // (*ContextType).func(*Job, NextMiddlewareFunc) error, (ContextType matches the type of ctx specified when creating a pool)
 // func(*Job, NextMiddlewareFunc) error, for the generic middleware format.
 func (wp *WorkerPool) Middleware(fn interface{}) *WorkerPool {
-	vfn := reflect.ValueOf(fn)
-	validateMiddlewareType(wp.contextType, vfn)
+	return wp.Middlewares([]interface{}{fn})
+}
 
-	mw := &middlewareHandler{
-		DynamicMiddleware: vfn,
-	}
-
-	if gmh, ok := fn.(func(*Job, NextMiddlewareFunc) error); ok {
-		mw.IsGeneric = true
-		mw.GenericMiddlewareHandler = gmh
-	}
-
-	wp.middleware = append(wp.middleware, mw)
+// Middlewares appends the specified functions to the middleware chain. The fn in fns can take one of these forms:
+// (*ContextType).func(*Job, NextMiddlewareFunc) error, (ContextType matches the type of ctx specified when creating a pool)
+// func(*Job, NextMiddlewareFunc) error, for the generic middleware format.
+func (wp *WorkerPool) Middlewares(fns []interface{}) *WorkerPool {
+	wp.middleware = funcToMiddleware(fns, wp.contextType)
 
 	for _, w := range wp.workers {
 		w.updateMiddlewareAndJobTypes(wp.middleware, wp.jobTypes)
@@ -152,20 +121,35 @@ func (wp *WorkerPool) Middleware(fn interface{}) *WorkerPool {
 // (*ContextType).func(*Job) error, (ContextType matches the type of ctx specified when creating a pool)
 // func(*Job) error, for the generic handler format.
 func (wp *WorkerPool) Job(name string, fn interface{}) *WorkerPool {
-	return wp.JobWithOptions(name, JobOptions{}, fn)
+	return wp.JobWithOptionsAndMiddlewares(name, JobOptions{}, fn, []interface{}{})
 }
 
 // JobWithOptions adds a handler for 'name' jobs as per the Job function, but permits you specify additional options
 // such as a job's priority, retry count, and whether to send dead jobs to the dead job queue or trash them.
 func (wp *WorkerPool) JobWithOptions(name string, jobOpts JobOptions, fn interface{}) *WorkerPool {
+	return wp.JobWithOptionsAndMiddlewares(name, jobOpts, fn, []interface{}{})
+}
+
+// JobWithMiddlewares adds middlewares for 'name' jobs as per the Job specified middlware chain
+func (wp *WorkerPool) JobWithMiddlewares(name string, fn interface{}, fns []interface{}) *WorkerPool {
+	return wp.JobWithOptionsAndMiddlewares(name, JobOptions{}, fn, fns)
+}
+
+// JobWithOptionsAndMiddlewares adds a handler for 'name' jobs as per the Job function, but permits you specify additional options
+// such as a job's priority, retry count, and whether to send dead jobs to the dead job queue or trash them.
+// And adds middlewares for 'name' jobs as per the Job specified middlware chain
+func (wp *WorkerPool) JobWithOptionsAndMiddlewares(name string, jobOpts JobOptions, fn interface{}, fns []interface{}) *WorkerPool {
 	jobOpts = applyDefaultsAndValidate(jobOpts)
 
 	vfn := reflect.ValueOf(fn)
 	validateHandlerType(wp.contextType, vfn)
+	jobMiddleware := funcToMiddleware(fns, wp.contextType)
+
 	jt := &jobType{
 		Name:           name,
 		DynamicHandler: vfn,
 		JobOptions:     jobOpts,
+		middleware:     jobMiddleware,
 	}
 	if gh, ok := fn.(func(*Job) error); ok {
 		jt.IsGeneric = true
@@ -307,6 +291,27 @@ func (wp *WorkerPool) writeConcurrencyControlsToRedis() {
 			logError("write_concurrency_controls_max_concurrency", err)
 		}
 	}
+}
+
+func funcToMiddleware(fns []interface{}, ctxType reflect.Type) []*middlewareHandler {
+	var middleware []*middlewareHandler
+	for _, fn := range fns {
+		vfn := reflect.ValueOf(fn)
+		validateMiddlewareType(ctxType, vfn)
+
+		mw := &middlewareHandler{
+			DynamicMiddleware: vfn,
+		}
+
+		if gmh, ok := fn.(func(*Job, NextMiddlewareFunc) error); ok {
+			mw.IsGeneric = true
+			mw.GenericMiddlewareHandler = gmh
+		}
+
+		middleware = append(middleware, mw)
+	}
+
+	return middleware
 }
 
 // validateContextType will panic if context is invalid

--- a/worker_pool.go
+++ b/worker_pool.go
@@ -100,13 +100,13 @@ func NewWorkerPool(ctx interface{}, concurrency uint, namespace string, pool *re
 // (*ContextType).func(*Job, NextMiddlewareFunc) error, (ContextType matches the type of ctx specified when creating a pool)
 // func(*Job, NextMiddlewareFunc) error, for the generic middleware format.
 func (wp *WorkerPool) JobMiddleware(jobName string, fn interface{}) *WorkerPool {
+	vfn := reflect.ValueOf(fn)
+	validateMiddlewareType(wp.contextType, vfn)
+
 	jt := wp.jobTypes[jobName]
 	if jt == nil {
 		return wp
 	}
-
-	vfn := reflect.ValueOf(fn)
-	validateMiddlewareType(wp.contextType, vfn)
 
 	jmw := &middlewareHandler{
 		DynamicMiddleware: vfn,

--- a/worker_pool_test.go
+++ b/worker_pool_test.go
@@ -112,18 +112,6 @@ func TestWorkerPoolValidations(t *testing.T) {
 
 		wp.Job("wat", TestWorkerPoolValidations)
 	}()
-
-	func() {
-		defer func() {
-			if panicErr := recover(); panicErr != nil {
-				assert.Regexp(t, "Your middleware function can have one of these signatures", fmt.Sprintf("%v", panicErr))
-			} else {
-				t.Errorf("expected a panic when using a bad job middleware")
-			}
-		}()
-
-		wp.JobMiddleware("wat", TestWorkerPoolValidations)
-	}()
 }
 
 func TestWorkersPoolRunSingleThreaded(t *testing.T) {

--- a/worker_pool_test.go
+++ b/worker_pool_test.go
@@ -112,6 +112,18 @@ func TestWorkerPoolValidations(t *testing.T) {
 
 		wp.Job("wat", TestWorkerPoolValidations)
 	}()
+
+	func() {
+		defer func() {
+			if panicErr := recover(); panicErr != nil {
+				assert.Regexp(t, "Your job middleware function can have one of these signatures", fmt.Sprintf("%v", panicErr))
+			} else {
+				t.Errorf("expected a panic when using a bad job middleware")
+			}
+		}()
+
+		wp.JobMiddleware("wat", TestWorkerPoolValidations)
+	}()
 }
 
 func TestWorkersPoolRunSingleThreaded(t *testing.T) {

--- a/worker_pool_test.go
+++ b/worker_pool_test.go
@@ -116,7 +116,7 @@ func TestWorkerPoolValidations(t *testing.T) {
 	func() {
 		defer func() {
 			if panicErr := recover(); panicErr != nil {
-				assert.Regexp(t, "Your job middleware function can have one of these signatures", fmt.Sprintf("%v", panicErr))
+				assert.Regexp(t, "Your middleware function can have one of these signatures", fmt.Sprintf("%v", panicErr))
 			} else {
 				t.Errorf("expected a panic when using a bad job middleware")
 			}

--- a/worker_test.go
+++ b/worker_test.go
@@ -155,6 +155,7 @@ func TestWorkerRetry(t *testing.T) {
 		JobOptions: JobOptions{Priority: 1, MaxFails: 3},
 		IsGeneric:  true,
 		GenericHandler: func(job *Job) error {
+			job.Failed(fmt.Errorf("sorry kid"))
 			return fmt.Errorf("sorry kid")
 		},
 	}
@@ -207,6 +208,7 @@ func TestWorkerRetryWithCustomBackoff(t *testing.T) {
 		JobOptions: JobOptions{Priority: 1, MaxFails: 3, Backoff: custombo},
 		IsGeneric:  true,
 		GenericHandler: func(job *Job) error {
+			job.Failed(fmt.Errorf("sorry kid"))
 			return fmt.Errorf("sorry kid")
 		},
 	}
@@ -254,6 +256,7 @@ func TestWorkerDead(t *testing.T) {
 		JobOptions: JobOptions{Priority: 1, MaxFails: 0},
 		IsGeneric:  true,
 		GenericHandler: func(job *Job) error {
+			job.Failed(fmt.Errorf("sorry kid1"))
 			return fmt.Errorf("sorry kid1")
 		},
 	}
@@ -262,6 +265,7 @@ func TestWorkerDead(t *testing.T) {
 		JobOptions: JobOptions{Priority: 1, MaxFails: 0, SkipDead: true},
 		IsGeneric:  true,
 		GenericHandler: func(job *Job) error {
+			job.Failed(fmt.Errorf("sorry kid2"))
 			return fmt.Errorf("sorry kid2")
 		},
 	}


### PR DESCRIPTION
Middleware are executed for each job now. 
Some jobs in pool may require some specified middleware, while others may not.
So I add a new middleware chain in JobType, and this middleware will be executed when the specified job runs.
Hope it helps