### PR TITLE
BUGFIX: Remove from InProgress if we don't addToDead

### DIFF
--- a/worker.go
+++ b/worker.go
@@ -240,7 +240,9 @@ func (w *worker) addToRetryOrDead(jt *jobType, job *Job, runErr error) {
 	if failsRemaining > 0 {
 		w.addToRetry(job, runErr)
 	} else {
-		if !jt.SkipDead {
+		if jt.SkipDead {
+			w.removeJobFromInProgress(job)
+		} else {
 			w.addToDead(job, runErr)
 		}
 	}

--- a/worker.go
+++ b/worker.go
@@ -241,7 +241,7 @@ func terminateOnly(_ redis.Conn) { return }
 func terminateAndRetry(w *worker, jt *jobType, job *Job) terminateOp {
 	rawJSON, err := job.serialize()
 	if err != nil {
-		logError("worker.add_to_retry", err)
+		logError("worker.terminate_and_retry.serialize", err)
 		return terminateOnly
 	}
 	return func(conn redis.Conn) {
@@ -251,7 +251,7 @@ func terminateAndRetry(w *worker, jt *jobType, job *Job) terminateOp {
 func terminateAndDead(w *worker, job *Job) terminateOp {
 	rawJSON, err := job.serialize()
 	if err != nil {
-		logError("worker.add_to_dead.serialize", err)
+		logError("worker.terminate_and_dead.serialize", err)
 		return terminateOnly
 	}
 	return func(conn redis.Conn) {

--- a/worker_pool.go
+++ b/worker_pool.go
@@ -1,12 +1,13 @@
 package work
 
 import (
-	"github.com/garyburd/redigo/redis"
-	"github.com/robfig/cron"
 	"reflect"
 	"sort"
 	"strings"
 	"sync"
+
+	"github.com/garyburd/redigo/redis"
+	"github.com/robfig/cron"
 )
 
 // WorkerPool represents a pool of workers. It forms the primary API of gocraft/work. WorkerPools provide the public API of gocraft/work. You can attach jobs and middlware to them. You can start and stop them. Based on their concurrency setting, they'll spin up N worker goroutines.
@@ -37,6 +38,13 @@ type jobType struct {
 	IsGeneric      bool
 	GenericHandler GenericHandler
 	DynamicHandler reflect.Value
+}
+
+func (jt *jobType) calcBackoff(j *Job) int64 {
+	if jt.Backoff == nil {
+		return defaultBackoffCalculator(j)
+	}
+	return jt.Backoff(j)
 }
 
 // You may provide your own backoff function for retrying failed jobs or use the builtin one.

--- a/worker_test.go
+++ b/worker_test.go
@@ -279,10 +279,16 @@ func TestWorkerDead(t *testing.T) {
 	// Ensure the right stuff is in our queues:
 	assert.EqualValues(t, 0, zsetSize(pool, redisKeyRetry(ns)))
 	assert.EqualValues(t, 1, zsetSize(pool, redisKeyDead(ns)))
+
 	assert.EqualValues(t, 0, listSize(pool, redisKeyJobs(ns, job1)))
 	assert.EqualValues(t, 0, listSize(pool, redisKeyJobsInProgress(ns, "1", job1)))
-	assert.EqualValues(t, 0, listSize(pool, redisKeyJobs(ns, job1)))
-	assert.EqualValues(t, 0, listSize(pool, redisKeyJobsInProgress(ns, "1", job1)))
+	assert.EqualValues(t, 0, getInt64(pool, redisKeyJobsLock(ns, job1)))
+	assert.EqualValues(t, 0, hgetInt64(pool, redisKeyJobsLockInfo(ns, job1), w.poolID))
+
+	assert.EqualValues(t, 0, listSize(pool, redisKeyJobs(ns, job2)))
+	assert.EqualValues(t, 0, listSize(pool, redisKeyJobsInProgress(ns, "1", job2)))
+	assert.EqualValues(t, 0, getInt64(pool, redisKeyJobsLock(ns, job2)))
+	assert.EqualValues(t, 0, hgetInt64(pool, redisKeyJobsLockInfo(ns, job2), w.poolID))
 
 	// Get the job on the dead queue
 	ts, job := jobOnZset(pool, redisKeyDead(ns))


### PR DESCRIPTION
Tracked down why locks were being retained by jobs that weren't running to this branch.  First commit is a simple fix.   Second commit is a bit more involved and pulls removeJobFromInProgress out of any branches to ensure it always runs.

Commit Messages:
* Remove from InProgress if we don't addToDead

* removeJobFromInProgress critically needs to run when a job is dispatched regardless of the outcome; otherwise locks are retained for the lifetime of the worker.  The easiest way to ensure it's called in every branch is to remove it from branches entirely.  Its behavior can be modified selectively by passing in a closure, which can perform redis operations inside the same transaction as the common housekeeping ops.

* Consistent error messages
