### PR TITLE
Update redigo location

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To enqueue jobs, you need to make an Enqueuer with a redis namespace and a redig
 package main
 
 import (
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 	"github.com/gocraft/work"
 )
 
@@ -56,7 +56,7 @@ In order to process jobs, you'll need to make a WorkerPool. Add middleware and j
 package main
 
 import (
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 	"github.com/gocraft/work"
 	"os"
 	"os/signal"

--- a/benches/bench_goworker/main.go
+++ b/benches/bench_goworker/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 	"github.com/benmanns/goworker"
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 	"github.com/gocraft/health"
 	"os"
 	"sync/atomic"

--- a/benches/bench_goworkers/main.go
+++ b/benches/bench_goworkers/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 	"github.com/gocraft/health"
 	"github.com/jrallison/go-workers"
 	"os"

--- a/benches/bench_jobs/main.go
+++ b/benches/bench_jobs/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 	"github.com/albrow/jobs"
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 	"github.com/gocraft/health"
 	"os"
 	"sync/atomic"

--- a/benches/bench_work/main.go
+++ b/benches/bench_work/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 	"github.com/gocraft/health"
 	"github.com/gocraft/work"
 	"os"

--- a/client.go
+++ b/client.go
@@ -2,7 +2,7 @@ package work
 
 import (
 	"fmt"
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 	"sort"
 	"strconv"
 	"strings"

--- a/client_test.go
+++ b/client_test.go
@@ -2,7 +2,7 @@ package work
 
 import (
 	"fmt"
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"

--- a/cmd/workenqueue/main.go
+++ b/cmd/workenqueue/main.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 	"github.com/gocraft/work"
 	"os"
 	"time"

--- a/cmd/workfakedata/main.go
+++ b/cmd/workfakedata/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 	"github.com/gocraft/work"
 	"math/rand"
 	"time"

--- a/cmd/workwebui/main.go
+++ b/cmd/workwebui/main.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 	"github.com/gocraft/work/webui"
 )
 

--- a/dead_pool_reaper.go
+++ b/dead_pool_reaper.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 )
 
 const (

--- a/dead_pool_reaper_test.go
+++ b/dead_pool_reaper_test.go
@@ -1,7 +1,7 @@
 package work
 
 import (
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"

--- a/enqueue.go
+++ b/enqueue.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 )
 
 // Enqueuer can enqueue jobs.

--- a/heartbeater.go
+++ b/heartbeater.go
@@ -2,7 +2,7 @@ package work
 
 import (
 	// "fmt"
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 	"os"
 	"sort"
 	"strings"

--- a/heartbeater_test.go
+++ b/heartbeater_test.go
@@ -2,7 +2,7 @@ package work
 
 import (
 	// "fmt"
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"

--- a/observer.go
+++ b/observer.go
@@ -3,7 +3,7 @@ package work
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 	"time"
 )
 

--- a/observer_test.go
+++ b/observer_test.go
@@ -2,7 +2,7 @@ package work
 
 import (
 	"fmt"
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 	"github.com/stretchr/testify/assert"
 	"testing"
 	// "time"

--- a/periodic_enqueuer.go
+++ b/periodic_enqueuer.go
@@ -2,7 +2,7 @@ package work
 
 import (
 	"fmt"
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 	"github.com/robfig/cron"
 	"math/rand"
 	"time"

--- a/periodic_enqueuer_test.go
+++ b/periodic_enqueuer_test.go
@@ -1,7 +1,7 @@
 package work
 
 import (
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 	"github.com/robfig/cron"
 	"github.com/stretchr/testify/assert"
 	"testing"

--- a/requeuer.go
+++ b/requeuer.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 )
 
 type requeuer struct {

--- a/requeuer_test.go
+++ b/requeuer_test.go
@@ -1,7 +1,7 @@
 package work
 
 import (
-	// "github.com/garyburd/redigo/redis"
+	// "github.com/gomodule/redigo/redis"
 	"github.com/stretchr/testify/assert"
 	"testing"
 	// "fmt"

--- a/webui/webui.go
+++ b/webui/webui.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 
 	"github.com/braintree/manners"
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 	"github.com/gocraft/web"
 	"github.com/gocraft/work"
 	"github.com/gocraft/work/webui/internal/assets"

--- a/webui/webui_test.go
+++ b/webui/webui_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 	"github.com/gocraft/work"
 	"github.com/stretchr/testify/assert"
 )

--- a/worker.go
+++ b/worker.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 )
 
 const fetchKeysPerJobType = 6

--- a/worker_pool.go
+++ b/worker_pool.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 	"github.com/robfig/cron"
 )
 

--- a/worker_pool_test.go
+++ b/worker_pool_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/worker_test.go
+++ b/worker_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
Redigo development has moved from https://github.com/garyburd/redigo/redis to https://github.com/gomodule/redigo/redis, this PR updates the references to the old location to point to the new location to avoid projects using the latest version of redigo needing to have both in their dependency tree.