### PR TITLE
Allow enqueueing unique jobs based on specified key

### DIFF
--- a/job.go
+++ b/job.go
@@ -15,6 +15,7 @@ type Job struct {
 	EnqueuedAt int64                  `json:"t"`
 	Args       map[string]interface{} `json:"args"`
 	Unique     bool                   `json:"unique,omitempty"`
+	UniqueKey  string                 `json:"unique_key,omitempty"`
 
 	// Inputs when retrying
 	Fails    int64  `json:"fails,omitempty"` // number of times this job has failed

--- a/redis.go
+++ b/redis.go
@@ -368,6 +368,19 @@ end
 return 'dup'
 `
 
+// KEYS[1] = job queue to push onto
+// KEYS[2] = Unique job's key. Test for existence and set if we push.
+// ARGV[1] = job
+var redisLuaEnqueueUniqueByKey = `
+if redis.call('set', KEYS[2], ARGV[1], 'NX', 'EX', '86400') then
+  redis.call('lpush', KEYS[1], ARGV[1])
+  return 'ok'
+else
+  redis.call('set', KEYS[2], ARGV[1], 'EX', '86400')
+end
+return 'dup'
+`
+
 // KEYS[1] = scheduled job queue
 // KEYS[2] = Unique job's key. Test for existence and set if we push.
 // ARGV[1] = job
@@ -376,6 +389,8 @@ var redisLuaEnqueueUniqueByKeyIn = `
 if redis.call('set', KEYS[2], ARGV[1], 'NX', 'EX', '86400') then
   redis.call('zadd', KEYS[1], ARGV[2], ARGV[1])
   return 'ok'
+else
+  redis.call('set', KEYS[2], ARGV[1], 'EX', '86400')
 end
 return 'dup'
 `

--- a/redis.go
+++ b/redis.go
@@ -367,3 +367,15 @@ if redis.call('set', KEYS[2], '1', 'NX', 'EX', '86400') then
 end
 return 'dup'
 `
+
+// KEYS[1] = scheduled job queue
+// KEYS[2] = Unique job's key. Test for existence and set if we push.
+// ARGV[1] = job
+// ARGV[2] = epoch seconds for job to be run at
+var redisLuaEnqueueUniqueByKeyIn = `
+if redis.call('set', KEYS[2], ARGV[1], 'NX', 'EX', '86400') then
+  redis.call('zadd', KEYS[1], ARGV[2], ARGV[1])
+  return 'ok'
+end
+return 'dup'
+`


### PR DESCRIPTION
Currently, when a unique job is enqueued, we put that job's unique key (formed with the arguments) on a special queue with an arbitrary value of 1, and put the arguments for that job in the actual job queue. If the same job is enqueued again, we check the existence of it's unique key, and if present do nothing.

To support using a user-defined key, we need a way of updating the arguments the second time a job with that key is enqueued. Since the arguments for the job currently live in an arbitrary spot on the queue and we have no reference back to those arguments, I am repurposing the arbitrary "1" assigned to that job key on the first queue to hold updated arguments. Then when we go to delete that key, we use the updated arguments to replace the job.