### PR TITLE
Fixes issue #133

### DIFF
--- a/periodic_enqueuer_test.go
+++ b/periodic_enqueuer_test.go
@@ -108,10 +108,13 @@ func TestPeriodicEnqueuerSpawn(t *testing.T) {
 }
 
 func appendPeriodicJob(pjs []*periodicJob, spec, jobName string) []*periodicJob {
-	sched, err := cron.Parse(spec)
+	p := cron.NewParser(cron.SecondOptional | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor)
+
+	sched, err := p.Parse(spec)
 	if err != nil {
 		panic(err)
 	}
+
 	pj := &periodicJob{jobName: jobName, spec: spec, schedule: sched}
 	return append(pjs, pj)
 }

--- a/worker_pool.go
+++ b/worker_pool.go
@@ -180,7 +180,9 @@ func (wp *WorkerPool) JobWithOptions(name string, jobOpts JobOptions, fn interfa
 // Note that the first value is the seconds!
 // If you have multiple worker pools on different machines, they'll all coordinate and only enqueue your job once.
 func (wp *WorkerPool) PeriodicallyEnqueue(spec string, jobName string) *WorkerPool {
-	schedule, err := cron.Parse(spec)
+	p := cron.NewParser(cron.SecondOptional | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor)
+
+	schedule, err := p.Parse(spec)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
- Remove cron.Prase per documentation of robfig/cron
- Fix tests
- Allow for normal `go get` to work

Fixes issue: #133

_**Note**_
This should prob use go.mod eventually so the dependany can be locked and issue resolved that way. 