### PR TITLE
Fix documentation of `workwebui`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,8 +251,12 @@ go install github.com/gocraft/work/cmd/workwebui
 
 Then, you can run it:
 ```bash
-workwebui -redis="redis:6379" -ns="work" -listen=":5040"
+workwebui -redis="redis://127.0.0.1:6379" -ns="work" -listen=":5040"
 ```
+
+For the `-redis` parameter, any Redis URI conforming to the
+[specification](https://www.iana.org/assignments/uri-schemes/prov/redis) is
+allowed - see its ABNF notation or example section for further details.
 
 Navigate to ```http://localhost:5040/```.
 

--- a/cmd/workwebui/main.go
+++ b/cmd/workwebui/main.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	redisHostPort  = flag.String("redis", ":6379", "redis hostport")
+	redisHostPort  = flag.String("redis", "redis://:6379", "redis URI")
 	redisDatabase  = flag.String("database", "0", "redis database")
 	redisNamespace = flag.String("ns", "work", "redis namespace")
 	webHostPort    = flag.String("listen", ":5040", "hostport to listen for HTTP JSON API")


### PR DESCRIPTION
Example URI was not a valid URI according to Redis' URI specification.
This commit fixes the example both in the readme, as well as the
binaries' helptext.