### PR TITLE
Correct "week of the day" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ For information on how this map will be serialized to form a unique key, see (ht
 
 ### Periodic Enqueueing (Cron)
 
-You can periodically enqueue jobs on your gocraft/work cluster using your worker pool. The [scheduling specification](https://godoc.org/github.com/robfig/cron#hdr-CRON_Expression_Format) uses a Cron syntax where the fields represent seconds, minutes, hours, day of the month, month, and week of the day, respectively. Even if you have multiple worker pools on different machines, they'll all coordinate and only enqueue your job once.
+You can periodically enqueue jobs on your gocraft/work cluster using your worker pool. The [scheduling specification](https://godoc.org/github.com/robfig/cron#hdr-CRON_Expression_Format) uses a Cron syntax where the fields represent seconds, minutes, hours, day of the month, month, and day of the week, respectively. Even if you have multiple worker pools on different machines, they'll all coordinate and only enqueue your job once.
 
 ```go
 pool := work.NewWorkerPool(Context{}, 10, "my_app_namespace", redisPool)


### PR DESCRIPTION
I believe the documentation for the cron syntax for scheduling periodically enqueued jobs should read "day of the week" instead.

E.g. from the [linked docs](https://pkg.go.dev/github.com/robfig/cron#hdr-CRON_Expression_Format)
![image](https://user-images.githubusercontent.com/19509185/163015875-fe943db3-bad3-4208-b2e9-a4d218edd708.png)
 