### PR TITLE
Add new functionality to check if a job is already registered in the worker pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,18 @@ pool.PeriodicallyEnqueue("0 0 * * * *", "calculate_caches") // This will enqueue
 pool.Job("calculate_caches", (*Context).CalculateCaches) // Still need to register a handler for this job separately
 ```
 
+### Check if a job is already registered
+
+You can check if a job is already registered in the worker pool.
+
+```go
+pool := work.NewWorkerPool(Context{}, 10, "my_app_namespace", redisPool)
+pool.Job("calculate_caches", (*Context).CalculateCaches)
+if pool.IsJobRegistered("calculate_caches") {
+    // do something
+}
+```
+
 ## Job concurrency
 
 You can control job concurrency using `JobOptions{MaxConcurrency: <num>}`. Unlike the WorkerPool concurrency, this controls the limit on the number jobs of that type that can be active at one time by within a single redis instance. This works by putting a precondition on enqueuing function, meaning a new job will not be scheduled if we are at or over a job's `MaxConcurrency` limit. A redis key (see `redis.go::redisKeyJobsLock`) is used as a counting semaphore in order to track job concurrency per job type. The default value is `0`, which means "no limit on job concurrency".

--- a/worker_pool.go
+++ b/worker_pool.go
@@ -175,6 +175,13 @@ func (wp *WorkerPool) JobWithOptions(name string, jobOpts JobOptions, fn interfa
 	return wp
 }
 
+// IsJobRegistered returns true if the job is already registered.
+// This is useful for checking if a job is already registered before registering it.
+func (wp *WorkerPool) IsJobRegistered(name string) bool {
+	_, ok := wp.jobTypes[name]
+	return ok
+}
+
 // PeriodicallyEnqueue will periodically enqueue jobName according to the cron-based spec.
 // The spec format is based on https://godoc.org/github.com/robfig/cron, which is a relatively standard cron format.
 // Note that the first value is the seconds!


### PR DESCRIPTION
This PR adds a feature that lets you know if a job has already been registered